### PR TITLE
Compatibility with recent JAX versions

### DIFF
--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2023 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 name: Build_pypi_wheels
 
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-24.04, macos-11]
         platform: [manylinux, musllinux, macosx]
         arch: [x86_64, arm64, aarch64, universal2]
         exclude:
@@ -26,11 +26,11 @@ jobs:
             platform: musllinux
           - os: macos-11
             arch: aarch64
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             platform: macosx
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: universal2
-          - os: ubuntu-20.04
+          - os: ubuntu-24.04
             arch: arm64
     steps:
       - uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build wheels CPU only
         if: ${{ !(matrix.platform == 'manylinux' && matrix.arch == 'x86_64') }}
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build wheels CUDA 11
         if: ${{ matrix.platform == 'manylinux' && matrix.arch == 'x86_64' }}
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_BUILD: "*-${{ matrix.platform }}*"
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/setup-python@v4
         name: Install Python
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Setup build environment
         run: pip install build

--- a/.github/workflows/build_wheels_and_publish.yml
+++ b/.github/workflows/build_wheels_and_publish.yml
@@ -59,7 +59,7 @@ jobs:
           CIBW_ENVIRONMENT_MACOS: JAX_CHACHA_PRNG_DISABLE_OPENMP=1
           # CIBW_ENVIRONMENT: JAX_CHACHA_PRNG_BUILD="cpu"
 
-      - name: Build wheels CUDA 11
+      - name: Build wheels CUDA 12
         if: ${{ matrix.platform == 'manylinux' && matrix.arch == 'x86_64' }}
         uses: pypa/cibuildwheel@v2
         env:
@@ -67,9 +67,9 @@ jobs:
           CIBW_BUILD: "*-${{ matrix.platform }}*"
           CIBW_BUILD_VERBOSITY: 2
           CIBW_BEFORE_ALL_LINUX: >
-            curl -o installer.run -s https://developer.download.nvidia.com/compute/cuda/11.2.2/local_installers/cuda_11.2.2_460.32.03_linux.run &&
+            curl -o installer.run https://developer.download.nvidia.com/compute/cuda/12.9.2/local_installers/cuda_12.9.2_575.57.08_linux.run &&
             /bin/sh ./installer.run --toolkit --silent
-          CIBW_ENVIRONMENT: PATH=/usr/local/cuda/bin:$PATH # JAX_CHACHA_PRNG_BUILD="cuda11.2"
+          CIBW_ENVIRONMENT: PATH=/usr/local/cuda/bin:$PATH
           CIBW_ENVIRONMENT_MACOS: JAX_CHACHA_PRNG_DISABLE_OPENMP=1
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/jax_compatibility_tests.yml
+++ b/.github/workflows/jax_compatibility_tests.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2023 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 name: Jax Compatibility Tests
 
@@ -10,12 +10,12 @@ on:
 
 jobs:
   unittests-with-minimum-jaxlib:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
         jax-version: [
-          0.4.1, 0.4.14
+          0.10.0, 0.10.2
         ]
 
     steps:
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/native_code_tests.yml
+++ b/.github/workflows/native_code_tests.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2022 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 name: Native code tests
 
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test_native_intel:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/native_code_tests.yml
+++ b/.github/workflows/native_code_tests.yml
@@ -46,31 +46,11 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
+    - name: Build cross-compilation container
+      run: docker build -t arm-cross-builder arm_container
     - name: Build and run in container
-      uses: addnab/docker-run-action@v3
-      with:
-        image: ubuntu:jammy
-        options: -v ${{ github.workspace }}:/work/src -e FORCE_GENERIC=${{ matrix.force_generic }}
-        run: |
-          sed -i 's/http/[arch=i386,amd64] http/g' /etc/apt/sources.list
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted" >> /etc/apt/sources.list
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted" >> /etc/apt/sources.list
-          dpkg --add-architecture arm64
-          apt-get update
-          apt-get upgrade -y
-          apt-get install -y qemu binfmt-support qemu-user-static libc6:arm64 \
-            gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross cmake python3 python3-dev libpython3-dev:arm64
-          mkdir /work/build
-          cd /work/build
-          cmake \
-            -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 \
-            -DCMAKE_C_COMPILER=/usr/bin/aarch64-linux-gnu-gcc \
-            -DCMAKE_CXX_COMPILER=/usr/bin/aarch64-linux-gnu-g++ \
-            -DCMAKE_FIND_ROOT_PATH=/usr/aarch64-linux-gnu/ \
-            -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=BOTH \
-            -DCMAKE_CROSSCOMPILING_EMULATOR="/usr/bin/qemu-aarch64-static;-L;/usr/aarch64-linux-gnu/" \
-            -DBUILD_TESTING=On \
-            -DFORCE_GENERIC=${{ matrix.force_generic }} \
-            -DCMAKE_BUILD_TYPE=Release ../src
-          make
-          /usr/bin/qemu-aarch64-static -L /usr/aarch64-linux-gnu/ ./cpu_kernel_tests
+      run: |
+        docker run --rm \
+          -v ${{ github.workspace }}:/work/src \
+          -e FORCE_GENERIC=${{ matrix.force_generic }} \
+          arm-cross-builder

--- a/.github/workflows/python_unittests.yml
+++ b/.github/workflows/python_unittests.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2021 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 name: Python Unittests
 
@@ -11,11 +11,11 @@ on:
 
 jobs:
   unittests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install environment
       run: |
         python -m pip install --upgrade pip
@@ -73,7 +73,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Install environment
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/testu01_small_crush.yml
+++ b/.github/workflows/testu01_small_crush.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2021 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 name: TestU01 Small Crush
 
@@ -10,7 +10,7 @@ on:
 
 jobs:
   small-crush:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v3
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - name: Download and Compile TestU01
       working-directory: rng_testsuite/extern
       run: |

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,7 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: jax-chacha-prng
-Source: https://github.com/DPBayes/jax-chacha-prng
-
-Files: extern/pybind11/*
-Copyright: (c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>, All rights reserved.
-License: LicenseRef-pybind11License

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2023 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 cmake_minimum_required(VERSION 3.21)
 project(jax-chacha20-prng LANGUAGES CXX)
@@ -129,6 +129,8 @@ target_compile_definitions(native PRIVATE ${cpu_arch_def})
 target_link_options(native PRIVATE "-s") # manually strip symbols from module; this does not run into the same
 # problem as letting Pybind do it for some reason...
 
+target_include_directories(native PRIVATE "extern/xla")
+
 if(OpenMP_CXX_FOUND)
     target_link_libraries(native PUBLIC OpenMP::OpenMP_CXX)
 endif()
@@ -155,9 +157,8 @@ if (CMAKE_CUDA_COMPILER)
     target_sources(native PRIVATE ${CMAKE_CURRENT_LIST_DIR}/lib/gpu_kernel.gpu.cpp)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/lib/gpu_kernel.gpu.cpp PROPERTIES LANGUAGE CUDA)
     set_source_files_properties(${CMAKE_CURRENT_LIST_DIR}/lib/python_bindings.cpp PROPERTIES LANGUAGE CUDA)
-    # compile for lowest compute capability supported by XLA: 3.5
-    # cf. https://www.tensorflow.org/install/gpu#hardware_requirements
-    set_property(TARGET native PROPERTY CUDA_ARCHITECTURES 35)
+    # compile for lowest compute capability supported by CUDA12: 5.0
+    set_property(TARGET native PROPERTY CUDA_ARCHITECTURES 50)
 
     if (BUILD_TESTING)
         add_executable(gpu_kernel_tests
@@ -168,7 +169,7 @@ if (CMAKE_CUDA_COMPILER)
         target_include_directories(gpu_kernel_tests PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/lib/)
         target_compile_definitions(gpu_kernel_tests PRIVATE ${cpu_arch_def})
-        set_property(TARGET gpu_kernel_tests PROPERTY CUDA_ARCHITECTURES 35)
+        set_property(TARGET native PROPERTY CUDA_ARCHITECTURES 50)
         if (OpenMP_CXX_FOUND)
             target_link_libraries(gpu_kernel_tests PUBLIC OpenMP::OpenMP_CXX)
         endif()

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,7 +1,8 @@
 - 2.0.0:
-    - Added: support for jax up to v0.4.14
-    - Removed: support for Python <v3.8 and jax before v0.4.1
+    - Added: support for jax v0.10.x
+    - Removed: support for Python before v3.11 and jax before v0.10.0
     - Added: GPU kernels can now be compiled for AMD HIP/ROCM
+    - Changed: Minimal compute capability for CUDA kernels is now 5.0
 - 1.4.1:
     - Fix: native module not built for correct Python verison for MacOS.
     - Fix: Wheels for MacOS no longer build with OpenMP to avoid complicatons with conda environments.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -2,8 +2,17 @@ MIT License
 
 Copyright (c) <year> <copyright holders>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The package currently exposes basic RNG functions using the same interface as `J
 
 *Note*: `PRNGKey` instances of this ChaCha20-based RNG are not interoperable with those of `jax.random`, i.e., you cannot mix them.
 
-**Security notice** Versions prior to 3.0.0 may repeat random states via the `split` and `fold_in` functions.
+**Security notice** Versions prior to 3.0.0 may repeat random states via the `split` and `fold_in` functions and thus result
+in identical random bit streams for different splits in rare occasions.
 
 #### Usage notes
 Per conventions of pseudo-random number generation in the `JAX` framework, the functions `random_bits` and `uniform` are
@@ -62,8 +63,8 @@ For the latest stable version install via pip
 pip install jax-chacha-prng
 ```
 
-Binaries for glibc based 64-bit linux systems (manylinux wheels) are compiled with CPU and CUDA 11 support (you will have to [install JAX with CUDA support](https://github.com/google/jax#pip-installation-gpu-cuda) to benefit from this).
-Binaries for all other systems are compiled for CPU execution only. This is because JAX does not have CUDA libraries for these systems either.
+Binaries for glibc based 64-bit linux systems (manylinux wheels) are compiled with CPU and CUDA 12 support (you will have to [install JAX with CUDA support](https://github.com/google/jax#pip-installation-gpu-cuda) to benefit from this).
+Binaries for all other systems are compiled for CPU execution only.
 
 However, you can instruct pip to instead compile the package from sources via
 ```
@@ -76,8 +77,10 @@ pip install git+https://github.com/DPBayes/jax-chacha-prng@v2-stable#egg=jax-cha
 ```
 
 This will compile CUDA kernels if the CUDA library is present on the system,
-otherwise only CPU kernels will be built. To check whether CUDA kernels were
-built and installed, you can check the return value of `chacha.native.cuda_supported()`.
+ROCm kernels if the ROCm library can be found and otherwise only CPU kernels.
+To check whether CUDA or ROCm kernels were built and installed, you can check
+the return value of `chacha.native.cuda_supported()` or `chacha.native.hip_supported()`
+respectively.
 
 ### Note about JAX versions
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,15 @@
+version = 1
+SPDX-PackageName = "jax-chacha-prng"
+SPDX-PackageDownloadLocation = "https://github.com/DPBayes/jax-chacha-prng"
+
+[[annotations]]
+path = "extern/pybind11/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "(c) 2016 Wenzel Jakob <wenzel.jakob@epfl.ch>, All rights reserved."
+SPDX-License-Identifier = "LicenseRef-pybind11License"
+
+[[annotations]]
+path = "extern/xla/**"
+precedence = "aggregate"
+SPDX-FileCopyrightText = "Copyright 2023 The OpenXLA Authors"
+SPDX-License-Identifier = "Apache-2.0"

--- a/arm_container/Dockerfile
+++ b/arm_container/Dockerfile
@@ -1,16 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2022 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 FROM ubuntu:jammy AS qemu-arm-base
 
 RUN sed -i 's/http/[arch=i386,amd64] http/g' /etc/apt/sources.list
-RUN echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted" >> /etc/apt/sources.list
-RUN echo "deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted" >> /etc/apt/sources.list
+ADD arm-cross-compile-sources.list /etc/apt/sources.list.d/
 
 RUN dpkg --add-architecture arm64
 RUN apt update && apt upgrade -y && apt install -y qemu binfmt-support qemu-user-static libc6:arm64
-
-RUN /bin/bash
 
 FROM qemu-arm-base
 

--- a/arm_container/arm-cross-compile-sources.list
+++ b/arm_container/arm-cross-compile-sources.list
@@ -1,0 +1,3 @@
+deb [arch=arm64] http://ports.ubuntu.com/ jammy main restricted
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-updates main restricted
+deb [arch=arm64] http://ports.ubuntu.com/ jammy-security main restricted

--- a/arm_container/arm-cross-compile-sources.list.license
+++ b/arm_container/arm-cross-compile-sources.list.license
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: © 2026 Aalto University

--- a/chacha/cipher.py
+++ b/chacha/cipher.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2021 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 """ A JAX-accelerated implementation of the 20-round ChaCha cipher.
 
@@ -146,7 +146,7 @@ def set_nonce(state: ChaChaState, nonce: jnp.ndarray) -> ChaChaState:
       The new ChaCha cipher state with the given nonce value.
     """
     assert jnp.shape(nonce) == (3,)
-    assert jnp.dtype(state) == jnp.dtype(nonce)
+    assert state.dtype == nonce.dtype
     return state.at[3, 1:4].set(nonce)
 
 

--- a/chacha/jax_ops.py
+++ b/chacha/jax_ops.py
@@ -1,189 +1,56 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2021 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 """ A JAX-accelerated implementation of the 20-round ChaCha cipher.
 
 This module sets up the native implementation of the ChaCha20 block function as JAX ops.
 """
 
-from chacha.defs import ChaChaState
+from chacha.defs import ChaChaState, ChaChaStateShape
 from functools import partial
 
 from enum import Enum
-from typing import Any, Tuple, Union, Sequence
+from typing import Callable
 
 import jax
-from jax.lib import xla_client
-from jax.interpreters import xla, batching, mlir
-from jaxlib.mlir import ir
 import jax.numpy as jnp
-import numpy as np  # type: ignore
+import jax._src.core
 
 import chacha.native
 
-# importing ShapedArray and dtypes
-try:
-    # post jax v0.4.13 (or so) location
-    from jax.core import ShapedArray  # type: ignore
-    from jax._src import dtypes  # type: ignore
-except (AttributeError, ImportError):  # pragma: no cover
-    try:
-        # post jax v0.2.14 location
-        from jax._src.abstract_arrays import ShapedArray  # type: ignore
-        from jax._src import dtypes  # type: ignore
-    except (AttributeError, ImportError):  # pragma: no cover
-        try:
-            # pre jax v0.2.14 location
-            from jax.abstract_arrays import ShapedArray  # type: ignore
-            from jax import dtypes  # type: ignore
-        except (AttributeError, ImportError):  # pragma: no cover
-            raise ImportError("Cannot import ShapedArray and dtypes. "
-                          "You are probably using an incompatible version of jax.")
-
-# importing XlaOp
-try:
-    # post jax v0.2.13 location
-    from jaxlib.xla_client import XlaOp  # type: ignore
-except (AttributeError, ImportError):  # pragma: no cover
-    try:
-        # pre jax v0.2.13 location
-        XlaOp = jax.xla.XlaOp  # type: ignore
-    except (AttributeError, ImportError):  # pragma: no cover
-        raise ImportError("Cannot import XlaOp. "
-                          "You are probably using an incompatible version of jax.")
-
-try:
-    from jaxlib.hlo_helpers import custom_call
-except (AttributeError, ImportError):
-    try:
-        from jaxlib.mhlo_helpers import custom_call
-    except (AttributeError, ImportError):
-        raise ImportError("Cannot import custom_call. "
-                          "You are probably using an incompatible version of jax.")
-
-xla_client.register_cpu_custom_call_target(
-    b"cpu_chacha20_block", chacha.native.cpu_chacha20_block_factory()
-)
-
-
-class Platform(Enum):
-    CPU = 1
-    GPU = 2
-
-
-def _chacha20_block_translation(
-        platform: Platform,
-        ctx: mlir.LoweringRuleContext, 
-        states: Union[ir.Value, Sequence[ir.Value]]
-        ) -> Sequence[Union[ir.Value, Sequence[ir.Value]]]:
-    state_type = mlir.ir.RankedTensorType(states.type)
-    state_shape = state_type.shape
-    layout = tuple(range(len(state_shape) - 1, -1, -1))
-
-    assert len(state_shape) >= 2
-    assert tuple(state_shape)[-2:] == (4, 4)
-
-    batch_dims = state_shape[:-2]
-    num_states = np.prod(batch_dims).astype(np.uint32)
-    num_states_bytes = int(np.prod(batch_dims)).to_bytes(4, 'little')
-
-    if platform == Platform.CPU:
-        call_ret = custom_call(
-            b"cpu_chacha20_block",
-            out_types=[state_type],
-            operands=[mlir.ir_constant(num_states), states],
-            operand_layouts=[(), layout],
-            result_layouts=[layout]
-        )
-    else:
-        call_ret = custom_call(
-            b"gpu_chacha20_block",
-            out_types=[state_type],
-            operands=[states],
-            operand_layouts=[layout],
-            result_layouts=[layout],
-            backend_config=num_states_bytes
-        )
-    return (call_ret,)
-
-
-def _chacha20_block_cpu_translation(
-        ctx: mlir.LoweringRuleContext, 
-        states: Union[ir.Value, Sequence[ir.Value]]
-        ) -> Sequence[Union[ir.Value, Sequence[ir.Value]]]:
-    return _chacha20_block_translation(Platform.CPU, ctx, states)
-
-
-def _chacha20_block_gpu_translation(
-        ctx: mlir.LoweringRuleContext, 
-        states: Union[ir.Value, Sequence[ir.Value]]
-        ) -> Sequence[Union[ir.Value, Sequence[ir.Value]]]:
-    return _chacha20_block_translation(Platform.GPU, ctx, states)
-
-
-def _chacha20_block_abstract_eval(states: jnp.ndarray) -> ShapedArray:
-    state_shape = states.shape
-    dtype = dtypes.canonicalize_dtype(states.dtype)
-    abstract_output = ShapedArray(state_shape, dtype)
-    return abstract_output
-   
-
-chacha20_p = jax.core.Primitive("chacha20")
-chacha20_p.multiple_results = False
-chacha20_p.def_impl(partial(xla.apply_primitive, chacha20_p))
-chacha20_p.def_abstract_eval(_chacha20_block_abstract_eval)
-
-# xla.backend_specific_translations["cpu"][chacha20_p] = _chacha20_block_cpu_translation
-mlir.register_lowering(chacha20_p, _chacha20_block_cpu_translation, platform="cpu")
-
-def register_gpu_target(platform: str):
-    xla_client.register_custom_call_target(
-        b"gpu_chacha20_block", chacha.native.gpu_chacha20_block_factory(), platform=platform.upper()
-    )
-    mlir.register_lowering(chacha20_p, _chacha20_block_gpu_translation, platform=platform.lower())
+import jax.ffi
+jax.ffi.register_ffi_target("cpu_chacha20_block", chacha.native.cpu_chacha20_block_factory(), platform="cpu") # jax.ffi.register_ffi_target(
 
 if chacha.native.cuda_supported():
-    register_gpu_target("cuda")
+    jax.ffi.register_ffi_target("cuda_chacha20_block", chacha.native.cuda_chacha20_block_factory(), platform="CUDA")
 
 if chacha.native.hip_supported():
-    register_gpu_target("rocm")
-
-
-## BATCHING RULE, FOR VMAP
-def _chacha20_block_batch(states: jnp.ndarray, batch_axes: Tuple[int]) -> Tuple[jnp.ndarray, int]:
-    # Our CPU/GPU primitive can already batch over arbitrary leading
-    # dimensions. So there's not really anything to do here.
-    # We don't even need to really care about which axis should be batched over:
-    # jax will take care of taking out the correct axis for nested calls to vmap
-    # and mapping it back to outputs, and in the end we will map over all potential batch
-    # dimensions, so we do not need to move any axes around here.
-
-    states = states[0]
-    batch_axis = batch_axes[0]
-
-    assert batch_axis < len(states.shape) - 2
-    assert len(states.shape) >= 3
-    assert states.shape[-2:] == (4, 4)
-
-    out_states = chacha20_p.bind(states)
-    return out_states, batch_axis
-
-
-batching.primitive_batchers[chacha20_p] = _chacha20_block_batch
-
+    jax.ffi.register_ffi_target("rocm_chacha20_block", chacha.native.rocm_chacha20_block_factory(), platform="ROCM")
 
 def chacha20_block(state: ChaChaState) -> ChaChaState:
-    if jnp.shape(state) not in ((4, 4), (16, 1), (16,)):
+    state_shape = jnp.shape(state)
+    # even if the total `state` array that ends up being passed in here has arbitrary leading
+    # batch dimensions, under vmap shape only shows up as that of a single state
+    if state_shape != ChaChaStateShape:
         raise ValueError(
-            f"Argument to chacha20_block did have unexpected shape. Did you pass a ChaCha state? "
-            f"Got: {jnp.shape(state)}, expected (4,4)."
-        )
-    if jnp.dtype(state) != jnp.uint32:
-        raise ValueError(
-            f"Argument to chacha20_block did have unexpected type. Did you pass a ChaCha state? "
-            f"Got: {jnp.dtype(state)}, expected uint32."
+            "Argument to chacha20_block has wrong shape. Did you pass a ChaCha state? "
+            f"Must be {ChaChaStateShape} but was {state_shape}"
         )
 
+    if state.dtype != jnp.uint32:
+        raise ValueError(
+            "Argument to chacha20_block did have unexpected type. Did you pass a ChaCha state? "
+            f"Got: {state.type}, expected uint32."
+        )
+    
+    shapeDtype = jax.ShapeDtypeStruct(state_shape, jnp.uint32)
+    
     # CAUTION: currently implicitly assumes that 4x4 matrix is represented as row-major array
-    ret = chacha20_p.bind(state)
-    return ret
+    def make_ffi_call(implementation_name: str) -> Callable[[ChaChaState], ChaChaState]:
+        return jax.ffi.ffi_call(
+            implementation_name, shapeDtype, vmap_method="broadcast_all"
+        )
+
+    return jax.lax.platform_dependent(
+        state, cpu=make_ffi_call("cpu_chacha20_block"), cuda=make_ffi_call("cuda_chacha20_block"), rocm=make_ffi_call("rocm_chacha20_block")
+    )

--- a/chacha/random.py
+++ b/chacha/random.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: © 2021 Aalto University
+# SPDX-FileCopyrightText: © 2026 Aalto University
 
 """ A cryptographically secure pseudo-random number generator for JAX.
 
@@ -20,7 +20,7 @@ The following invariants hold:
 import numpy as np  # type: ignore
 import jax
 import jax.numpy as jnp
-from jax._src.random import _check_shape
+from jax._src import dtypes
 import typing
 from functools import partial
 import deprecation
@@ -29,33 +29,17 @@ import chacha.cipher as cc
 from chacha import defs
 from chacha.version import VERSION
 
-# importing canonicalize_shape function
-try:
-    # pre jax v0.2.14 location
-    _canonicalize_shape = jax.abstract_arrays.canonicalize_shape  # type: ignore
-except (AttributeError, ImportError):  # pragma: no cover
-    # post jax v0.2.14 location
-    try:
-        _canonicalize_shape = jax.core.canonicalize_shape  # type: ignore
-    except (AttributeError, ImportError):  # pragma: no cover
-        raise ImportError("Cannot import canonicalize_shape routine. "
-                          "You are probably using an incompatible version of jax.")
-
-# importing _UINT_DTYPES
-try:
-    # pre jax v0.2.20 location
-    _UINT_DTYPES = jax._src.random._UINT_DTYPES  # type: ignore
-except (AttributeError, ImportError):  # pragma: no cover
-    # post jax v.2.20 location
-    try:
-        from jax._src.random import UINT_DTYPES as _UINT_DTYPES  # type: ignore
-    except (AttributeError, ImportError) as e:  # pragma: no cover
-        raise ImportError("Cannot import UINT_DTYPES enum. "
-                          "You are probably using an incompatible version of jax.")
-
+from jax._src.core import canonicalize_shape
 
 RNGState = cc.ChaChaState
 
+allowed_bit_widths = frozenset({dtype.itemsize * 8 for dtype in dtypes._unsigned_types})
+_UINT_DTYPES = {
+    8: jnp.uint8,
+    16: jnp.uint16,
+    32: jnp.uint32,
+    64: jnp.uint64,
+}
 
 @partial(jax.jit, static_argnums=(1, 2))
 def random_bits(rng_key: RNGState, bit_width: int, shape: typing.Sequence[int]) -> jnp.ndarray:
@@ -69,8 +53,10 @@ def random_bits(rng_key: RNGState, bit_width: int, shape: typing.Sequence[int]) 
     Returns:
       An array of the given shape containing uniformly random unsigned integers with the given bit width.
     """
+    # assert dtypes.issubdtype(rng_key.dtype, dtypes.prng_key)
     if bit_width not in _UINT_DTYPES:
         raise ValueError(f"requires bit field width in {_UINT_DTYPES.keys()}")
+
     size = int(np.prod(shape, dtype=int))
     num_bits = bit_width * size
     num_blocks = int(np.ceil(num_bits / cc.ChaChaStateBitSize))
@@ -96,7 +82,7 @@ def _split(rng_key: RNGState, num: int) -> RNGState:
 
     def make_rng_key(nonce: jnp.ndarray) -> RNGState:
         assert jnp.shape(nonce) == (defs.ChaChaNonceSizeInWords,)
-        assert jnp.dtype(nonce) == defs.ChaChaStateElementType
+        assert nonce.dtype == defs.ChaChaStateElementType
         return cc.set_counter(cc.set_nonce(rng_key, nonce), 0)
 
     return jax.vmap(make_rng_key)(ivs)
@@ -119,7 +105,7 @@ def _uniform(
         minval: jnp.float_,
         maxval: jnp.float_
     ) -> jnp.ndarray:  # noqa:E121,E125
-    _check_shape("uniform", shape)
+    shape = canonicalize_shape(shape)
     if not jnp.issubdtype(dtype, np.floating):
         print("encountered exc in _uniform")
         raise TypeError("uniform only accepts floating point dtypes.")
@@ -218,5 +204,5 @@ def uniform(
     if not jax.dtypes.issubdtype(dtype, np.floating):
         raise TypeError(f"dtype argument to `uniform` must be a float dtype, got {dtype}")
     dtype = jax.dtypes.canonicalize_dtype(dtype)
-    shape = _canonicalize_shape(shape)
+    shape = canonicalize_shape(shape)
     return _uniform(key, shape, dtype, minval, maxval)

--- a/extern/xla/xla/ffi/api/api.h
+++ b/extern/xla/xla/ffi/api/api.h
@@ -1,0 +1,2302 @@
+/* Copyright 2023 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_FFI_API_API_H_
+#define XLA_FFI_API_API_H_
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+// This is a header-only base C++ library that defines templates for decoding
+// XLA FFI call frames and invoking corresponding C++ functions. This must have
+// no dependencies outside of the C++ standard library.
+//
+// There are two extensions to this base library:
+//
+//   (1) xla/ffi/api/ffi.h for defining "external" FFI handlers loaded from
+//       dynamic libraries potentially built with different toolchains and/or
+//       a different XLA commit. It is a header-only library without any
+//       dependencies.
+//
+//   (2) xla/ffi/ffi.h for defining "internal" FFI handlers that must be
+//       statically linked into the binary and must be built from the same
+//       commit using the same toolchain, as it provides access to XLA
+//       implementation details (e.g. ServiceExecutableOptions) and C++ ABI
+//       across different libraries is hard.
+//
+// Extensions define template specializations for argument-decoding hooks
+// defined in this file.
+
+#include "xla/ffi/api/c_api.h"
+
+#ifdef __has_builtin
+#define XLA_FFI_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define XLA_FFI_HAS_BUILTIN(x) 0
+#endif
+
+#if __has_attribute(always_inline)
+#define XLA_FFI_ATTRIBUTE_ALWAYS_INLINE __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define XLA_FFI_ATTRIBUTE_ALWAYS_INLINE __forceinline
+#else
+#define XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+#endif
+
+#if __has_attribute(noinline)
+#define XLA_FFI_ATTRIBUTE_NEVER_INLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define XLA_FFI_ATTRIBUTE_NEVER_INLINE __declspec(noinline)
+#else
+#define XLA_FFI_ATTRIBUTE_NEVER_INLINE
+#endif
+
+#if XLA_FFI_HAS_BUILTIN(__builtin_expect)
+#define XLA_FFI_PREDICT_FALSE(x) (__builtin_expect(false || (x), false))
+#define XLA_FFI_PREDICT_TRUE(x) (__builtin_expect(false || (x), true))
+#else
+#define XLA_FFI_PREDICT_FALSE(x) (x)
+#define XLA_FFI_PREDICT_TRUE(x) (x)
+#endif
+
+//===----------------------------------------------------------------------===//
+// Builtin enum pretty printing
+//===----------------------------------------------------------------------===//
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const XLA_FFI_DataType dtype) {
+  switch (dtype) {
+    case XLA_FFI_DataType_INVALID:
+      return os << "INVALID";
+    case XLA_FFI_DataType_PRED:
+      return os << "PRED";
+    case XLA_FFI_DataType_S1:
+      return os << "S1";
+    case XLA_FFI_DataType_S2:
+      return os << "S2";
+    case XLA_FFI_DataType_S4:
+      return os << "S4";
+    case XLA_FFI_DataType_S8:
+      return os << "S8";
+    case XLA_FFI_DataType_S16:
+      return os << "S16";
+    case XLA_FFI_DataType_S32:
+      return os << "S32";
+    case XLA_FFI_DataType_S64:
+      return os << "S64";
+    case XLA_FFI_DataType_U1:
+      return os << "U1";
+    case XLA_FFI_DataType_U2:
+      return os << "U2";
+    case XLA_FFI_DataType_U4:
+      return os << "U4";
+    case XLA_FFI_DataType_U8:
+      return os << "U8";
+    case XLA_FFI_DataType_U16:
+      return os << "U16";
+    case XLA_FFI_DataType_U32:
+      return os << "U32";
+    case XLA_FFI_DataType_U64:
+      return os << "U64";
+    case XLA_FFI_DataType_F16:
+      return os << "F16";
+    case XLA_FFI_DataType_F32:
+      return os << "F32";
+    case XLA_FFI_DataType_F64:
+      return os << "F64";
+    case XLA_FFI_DataType_BF16:
+      return os << "BF16";
+    case XLA_FFI_DataType_C64:
+      return os << "C64";
+    case XLA_FFI_DataType_C128:
+      return os << "C128";
+    case XLA_FFI_DataType_TOKEN:
+      return os << "TOKEN";
+    case XLA_FFI_DataType_F4E2M1FN:
+      return os << "F4E2M1FN";
+    case XLA_FFI_DataType_F8E5M2:
+      return os << "F8E5M2";
+    case XLA_FFI_DataType_F8E3M4:
+      return os << "F8E3M4";
+    case XLA_FFI_DataType_F8E4M3:
+      return os << "F8E4M3";
+    case XLA_FFI_DataType_F8E4M3FN:
+      return os << "F8E4M3FN";
+    case XLA_FFI_DataType_F8E4M3B11FNUZ:
+      return os << "F8E4M3B11FNUZ";
+    case XLA_FFI_DataType_F8E5M2FNUZ:
+      return os << "F8E5M2FNUZ";
+    case XLA_FFI_DataType_F8E4M3FNUZ:
+      return os << "F8E4M3FNUZ";
+    case XLA_FFI_DataType_F8E8M0FNU:
+      return os << "F8E8M0FNU";
+  }
+}
+
+inline std::ostream& operator<<(std::ostream& os, const XLA_FFI_AttrType type) {
+  switch (type) {
+    case XLA_FFI_AttrType_ARRAY:
+      return os << "array";
+    case XLA_FFI_AttrType_DICTIONARY:
+      return os << "dictionary";
+    case XLA_FFI_AttrType_SCALAR:
+      return os << "scalar";
+    case XLA_FFI_AttrType_STRING:
+      return os << "string";
+  }
+}
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const XLA_FFI_ExecutionStage stage) {
+  switch (stage) {
+    case XLA_FFI_ExecutionStage_INSTANTIATE:
+      return os << "instantiate";
+    case XLA_FFI_ExecutionStage_PREPARE:
+      return os << "prepare";
+    case XLA_FFI_ExecutionStage_INITIALIZE:
+      return os << "initialize";
+    case XLA_FFI_ExecutionStage_EXECUTE:
+      return os << "execute";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Builtin structs equality
+//===----------------------------------------------------------------------===//
+
+inline bool operator==(const XLA_FFI_TypeId& a, const XLA_FFI_TypeId& b) {
+  return a.type_id == b.type_id;
+}
+
+inline bool operator!=(const XLA_FFI_TypeId& a, const XLA_FFI_TypeId& b) {
+  return !(a == b);
+}
+
+inline bool operator==(const XLA_FFI_Api_Version& a,
+                       const XLA_FFI_Api_Version& b) {
+  return a.major_version == b.major_version &&
+         a.minor_version == b.minor_version;
+}
+
+inline bool operator!=(const XLA_FFI_Api_Version& a,
+                       const XLA_FFI_Api_Version& b) {
+  return !(a == b);
+}
+
+inline bool operator==(const XLA_FFI_Metadata& a, const XLA_FFI_Metadata& b) {
+  return a.api_version == b.api_version && a.traits == b.traits &&
+         a.state_type_id == b.state_type_id;
+}
+
+inline bool operator!=(const XLA_FFI_Metadata& a, const XLA_FFI_Metadata& b) {
+  return !(a == b);
+}
+
+inline bool operator==(const XLA_FFI_Handler_Bundle& a,
+                       const XLA_FFI_Handler_Bundle& b) {
+  return a.instantiate == b.instantiate && a.prepare == b.prepare &&
+         a.initialize == b.initialize && a.execute == b.execute;
+}
+
+inline bool operator!=(const XLA_FFI_Handler_Bundle& a,
+                       const XLA_FFI_Handler_Bundle& b) {
+  return !(a == b);
+}
+
+namespace xla::ffi {
+
+enum class ExecutionStage : uint8_t {
+  kInstantiate = XLA_FFI_ExecutionStage_INSTANTIATE,
+  kPrepare = XLA_FFI_ExecutionStage_PREPARE,
+  kInitialize = XLA_FFI_ExecutionStage_INITIALIZE,
+  kExecute = XLA_FFI_ExecutionStage_EXECUTE,
+};
+
+enum class Traits : uint32_t {
+  // Indicates that the handler is compatible with command buffers. In the
+  // XLA:GPU CUDA backend, we rely on graph capture to trace the execution of a
+  // FFI handler and record it as a command buffer (CUDA graph). For a FFI
+  // handler to be compatible with CUDA graphs, it has to satisfy certain
+  // constraints as documented in
+  // https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#prohibited-and-unhandled-operations.
+  //
+  // Broadly speaking, a handler that satisfies the following conditions should
+  // be compatible with command buffers:
+  //   1. it only launches kernels that must be captured in command buffers on
+  //      the device (e.g. it does *not* do autotuning). This is because
+  //      everything it launches will be captured in the command buffer;
+  //   2. the FFI handler only uses device allocations passed in as buffer
+  //      arguments (e.g. it does *not* do any runtime device memory
+  //      allocations);
+  //   3. the FFI handler may not query the execution status of the stream.
+  kCmdBufferCompatible = XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE,
+};
+
+// Forward declare template defined below.
+template <ExecutionStage stage, typename... Ts>
+class Binding;
+
+// Forward declare template defined below.
+template <ExecutionStage stage, typename Fn, typename... Ts>
+class Handler;
+
+//===----------------------------------------------------------------------===//
+// XLA FFI virtual base for implementing FFI handlers
+//===----------------------------------------------------------------------===//
+
+class Ffi {
+ public:
+  // Creates an empty binding specification which allows to define FFI handler
+  // signature separately from implementation and rely on compile time type
+  // checking to verify that signature matches the provided implementation.
+  template <ExecutionStage stage = ExecutionStage::kExecute>
+  static Binding<stage> Bind();
+
+  // Creates an empty binding for the instantiate stage.
+  static Binding<ExecutionStage::kInstantiate> BindInstantiate();
+
+  // Creates an empty binding for the prepare stage.
+  static Binding<ExecutionStage::kPrepare> BindPrepare();
+
+  // Creates an empty binding for the initialize stage.
+  static Binding<ExecutionStage::kInitialize> BindInitialize();
+
+  // Creates an empty binding for the execute stage.
+  static Binding<ExecutionStage::kExecute> BindExecute();
+
+  // Automatic FFI binding that does binding specification inference from the
+  // `fn` type signature and binds `fn` to it. This enables a more concise FFI
+  // handler registration with fully automatic type inference at the cost of
+  // less readable error messages, template metaprograming "magic" and a risk
+  // to accidentally change handler type without noticing it.
+  template <typename Fn, ExecutionStage stage = ExecutionStage::kExecute>
+  static auto BindTo(Fn fn, std::initializer_list<Traits> traits = {});
+
+  virtual ~Ffi() = default;
+  virtual XLA_FFI_Error* Call(XLA_FFI_CallFrame* call_frame) const = 0;
+
+  // Registers FFI handler bundle with an XLA runtime under the given name on a
+  // given platform.
+  static XLA_FFI_Error* RegisterStaticHandler(
+      const XLA_FFI_Api* api, std::string_view name, std::string_view platform,
+      XLA_FFI_Handler_Bundle bundle, XLA_FFI_Handler_Traits traits = 0);
+
+  // Registers FFI execute handler with an XLA runtime under the given name on a
+  // given platform.
+  static XLA_FFI_Error* RegisterStaticHandler(
+      const XLA_FFI_Api* api, std::string_view name, std::string_view platform,
+      XLA_FFI_Handler* execute, XLA_FFI_Handler_Traits traits = 0) {
+    return RegisterStaticHandler(
+        api, name, platform,
+        XLA_FFI_Handler_Bundle{nullptr, nullptr, nullptr, execute}, traits);
+  }
+
+  // Registers a custom type so that it can be used with State and UserData
+  // arguments to external FFI handlers. The `name` argument must be a unique
+  // identifier for the type, and duplicate registrations with the same name
+  // are not allowed. When successful, a unique ID will be returned by updating
+  // `type_id`.
+  static XLA_FFI_Error* RegisterTypeId(const XLA_FFI_Api* api,
+                                       std::string_view name,
+                                       XLA_FFI_TypeId* type_id,  // in-out
+                                       XLA_FFI_TypeInfo type_info);
+
+  static XLA_FFI_Error* RegisterTypeId(const XLA_FFI_Api* api,
+                                       std::string_view name,
+                                       XLA_FFI_TypeId* type_id,  // in-out
+                                       const XLA_FFI_TypeInfo* type_info);
+
+  // This is a helper template that allows to convert function pointers from
+  // the run time values to compile time values (template arguments) with
+  // automatic template arguments deduction.
+  //
+  // Example:
+  //
+  //   static Error Foo(int32_t arg) {... }
+  //
+  //   template<typename Callable>
+  //   void call(Callable callable) { callable(42); }
+  //
+  //   call(Foo);                  // `Foo` passed as a runtime value
+  //   call(Ffi::Wrapper<Foo>())   // `Foo` passed as a template argument
+  //
+  // In the first case compiler will not be able to inline `Foo` into the `call`
+  // body. However in the second case it can do that, because function pointer
+  // is a statically known value (template non-type argument).
+  template <auto fn>
+  struct Wrapper;
+
+  template <typename Ret, typename... Args, Ret (*fn)(Args...)>
+  struct Wrapper<fn> {
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE Ret operator()(Args... args) const {
+      return fn(std::forward<Args>(args)...);
+    }
+  };
+
+ protected:
+  template <typename... Args>
+  static std::string StrCat(Args... args);
+
+  static XLA_FFI_Error* Success();
+
+  static XLA_FFI_Error* MakeError(const XLA_FFI_Api* api,
+                                  XLA_FFI_Error_Code errc, std::string message);
+
+  static XLA_FFI_Error* InvalidArgument(const XLA_FFI_Api* api,
+                                        std::string message);
+
+  static XLA_FFI_Error* FailedPrecondition(const XLA_FFI_Api* api,
+                                           std::string message);
+
+  static XLA_FFI_Error* CheckStructSize(const XLA_FFI_Api* api,
+                                        std::string_view struct_name,
+                                        size_t expected, size_t actual);
+
+  static XLA_FFI_Error* StructSizeIsGreaterOrEqual(const XLA_FFI_Api* api,
+                                                   std::string_view struct_name,
+                                                   size_t expected,
+                                                   size_t actual);
+};
+
+inline XLA_FFI_Error* Ffi::RegisterStaticHandler(
+    const XLA_FFI_Api* api, std::string_view name, std::string_view platform,
+    XLA_FFI_Handler_Bundle bundle, XLA_FFI_Handler_Traits traits) {
+  XLA_FFI_Handler_Register_Args args;
+  args.struct_size = XLA_FFI_Handler_Register_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.name = XLA_FFI_ByteSpan{name.data(), name.size()};
+  args.platform = XLA_FFI_ByteSpan{platform.data(), platform.size()};
+  args.bundle = bundle;
+  args.traits = traits;
+  return api->XLA_FFI_Handler_Register(&args);
+}
+
+inline XLA_FFI_Error* Ffi::RegisterTypeId(const XLA_FFI_Api* api,
+                                          std::string_view name,
+                                          XLA_FFI_TypeId* type_id,
+                                          XLA_FFI_TypeInfo type_info) {
+  return RegisterTypeId(api, name, type_id, &type_info);
+}
+
+inline XLA_FFI_Error* Ffi::RegisterTypeId(const XLA_FFI_Api* api,
+                                          std::string_view name,
+                                          XLA_FFI_TypeId* type_id,
+                                          const XLA_FFI_TypeInfo* type_info) {
+  assert(type_id && "type_id must not be null");
+  XLA_FFI_Type_Register_Args args;
+  args.struct_size = XLA_FFI_Type_Register_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.name = XLA_FFI_ByteSpan{name.data(), name.size()};
+  args.type_id = type_id;
+  args.type_info = type_info;
+  return api->XLA_FFI_Type_Register(&args);
+}
+
+template <typename... Args>
+std::string Ffi::StrCat(Args... args) {
+  std::stringstream ss;
+  (ss << ... << args);
+  return ss.str();
+}
+
+inline XLA_FFI_Error* Ffi::Success() { return nullptr; }
+
+inline XLA_FFI_Error* Ffi::MakeError(const XLA_FFI_Api* api,
+                                     XLA_FFI_Error_Code errc,
+                                     std::string message) {
+  XLA_FFI_Error_Create_Args args;
+  args.struct_size = XLA_FFI_Error_Create_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.errc = errc;
+  args.message = message.c_str();
+  return api->XLA_FFI_Error_Create(&args);
+}
+
+inline XLA_FFI_Error* Ffi::InvalidArgument(const XLA_FFI_Api* api,
+                                           std::string message) {
+  return MakeError(api, XLA_FFI_Error_Code_INVALID_ARGUMENT,
+                   std::move(message));
+}
+
+inline XLA_FFI_Error* Ffi::FailedPrecondition(const XLA_FFI_Api* api,
+                                              std::string message) {
+  return MakeError(api, XLA_FFI_Error_Code_FAILED_PRECONDITION,
+                   std::move(message));
+}
+
+inline XLA_FFI_Error* Ffi::CheckStructSize(const XLA_FFI_Api* api,
+                                           std::string_view struct_name,
+                                           size_t expected, size_t actual) {
+  if (XLA_FFI_PREDICT_FALSE(expected != actual)) {
+    return InvalidArgument(
+        api, StrCat("Unexpected ", struct_name, " size: expected ", expected,
+                    " got ", actual, ". Check installed software versions."));
+  }
+  return nullptr;
+}
+
+inline XLA_FFI_Error* Ffi::StructSizeIsGreaterOrEqual(
+    const XLA_FFI_Api* api, std::string_view struct_name, size_t expected,
+    size_t actual) {
+  if (XLA_FFI_PREDICT_FALSE(actual < expected)) {
+    return InvalidArgument(
+        api, StrCat("Unexpected ", struct_name, " size: expected at least ",
+                    expected, " got ", actual,
+                    ". Check installed software versions."));
+  }
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// XLA_FFI_Error helpers
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+inline void DestroyError(const XLA_FFI_Api* api, XLA_FFI_Error* error) {
+  XLA_FFI_Error_Destroy_Args args;
+  args.struct_size = XLA_FFI_Error_Destroy_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.error = error;
+  api->XLA_FFI_Error_Destroy(&args);
+}
+
+inline const char* GetErrorMessage(const XLA_FFI_Api* api,
+                                   XLA_FFI_Error* error) {
+  XLA_FFI_Error_GetMessage_Args args;
+  args.struct_size = XLA_FFI_Error_GetMessage_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.error = error;
+  api->XLA_FFI_Error_GetMessage(&args);
+  return args.message;
+}
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Type tags for distinguishing handler argument types
+//===----------------------------------------------------------------------===//
+
+// Dictionary gives type-safe run time access to all attributes. Concrete
+// implementation is provided by the `ffi.h` header.
+class Dictionary;
+
+// Context gives run time access to the execution context. Concrete
+// implementation is provided by the `ffi.h` header.
+class Context;
+
+namespace internal {
+
+// WARNING: A lot of template metaprograming on top of C++ variadic templates
+// parameter packs. We need this to be able to pattern match FFI handler
+// signature at compile time.
+
+// A type tag for decoding argument.
+template <typename T>
+struct ArgTag {};
+
+// A type tag for decoding optional argument.
+template <typename T>
+struct OptionalArgTag {};
+
+// A type tag to forward all remaining args as `RemainingArgs`.
+struct RemainingArgsTag {};
+
+// A type tag to distinguish parameters tied to results in the `Binding`
+// variadic template. In XLA FFI we use destination passing style APIs and don't
+// return anything from the handler, but instead pass a destination where the
+// handler should write the result.
+template <typename T>
+struct RetTag {};
+
+// A type tag for decoding optional result.
+template <typename T>
+struct OptionalRetTag {};
+
+// A type tag to forward all remaining results as `RemainingRets`.
+struct RemainingRetsTag {};
+
+// A type tag to distinguish parameters tied to the attributes in the
+// `Binding` variadic template.
+template <typename T>
+struct AttrTag {};
+
+// A type tag to forward all attributes as `Dictionary` (and optionally decode
+// it into a custom struct).
+template <typename T>
+struct AttrsTag {};
+
+// A type tag to distinguish parameter extracted from an execution context.
+template <typename T>
+struct CtxTag {};
+
+//----------------------------------------------------------------------------//
+// A template for counting tagged arguments in the Ts pack.
+//----------------------------------------------------------------------------//
+
+template <template <typename> typename Tag, typename... Ts>
+struct NumTagged;
+
+template <template <typename> typename Tag>
+struct NumTagged<Tag> {
+  static constexpr int64_t value = 0;
+};
+
+template <template <typename> typename Tag, typename T, typename... Ts>
+struct NumTagged<Tag, Tag<T>, Ts...> {
+  static constexpr int64_t value = 1 + NumTagged<Tag, Ts...>::value;
+};
+
+template <template <typename> typename Tag, typename T, typename... Ts>
+struct NumTagged<Tag, T, Ts...> {
+  static constexpr int64_t value = 0 + NumTagged<Tag, Ts...>::value;
+};
+
+//----------------------------------------------------------------------------//
+
+template <typename T>
+struct IsOptionalArgTag : std::false_type {};
+template <typename T>
+struct IsOptionalArgTag<OptionalArgTag<T>> : std::true_type {};
+
+template <typename T>
+struct IsOptionalRetTag : std::false_type {};
+template <typename T>
+struct IsOptionalRetTag<OptionalRetTag<T>> : std::true_type {};
+
+// Checks if parameter pack has an optional argument.
+template <typename... Ts>
+using HasOptionalArgTag = std::disjunction<IsOptionalArgTag<Ts>...>;
+
+// Checks if parameter pack has remaining arguments.
+template <typename... Ts>
+using HasRemainingArgsTag =
+    std::disjunction<std::is_same<RemainingArgsTag, Ts>...>;
+
+// Checks if parameter pack has an optional result.
+template <typename... Ts>
+using HasOptionalRetTag = std::disjunction<IsOptionalRetTag<Ts>...>;
+
+// Checks if parameter pack has remaining results.
+template <typename... Ts>
+using HasRemainingRetsTag =
+    std::disjunction<std::is_same<RemainingRetsTag, Ts>...>;
+
+//----------------------------------------------------------------------------//
+
+template <typename T>
+constexpr XLA_FFI_DataType NativeTypeToCApiDataType() {
+  if constexpr (std::is_same_v<T, char>) {
+    return XLA_FFI_DataType_U8;
+  } else if constexpr (std::is_same_v<T, bool>) {
+    return XLA_FFI_DataType_PRED;
+  } else if constexpr (std::is_same_v<T, int8_t>) {
+    return XLA_FFI_DataType_S8;
+  } else if constexpr (std::is_same_v<T, int16_t>) {
+    return XLA_FFI_DataType_S16;
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    return XLA_FFI_DataType_S32;
+  } else if constexpr (std::is_same_v<T, int64_t>) {
+    return XLA_FFI_DataType_S64;
+  } else if constexpr (std::is_same_v<T, uint8_t>) {
+    return XLA_FFI_DataType_U8;
+  } else if constexpr (std::is_same_v<T, uint16_t>) {
+    return XLA_FFI_DataType_U16;
+  } else if constexpr (std::is_same_v<T, uint32_t>) {
+    return XLA_FFI_DataType_U32;
+  } else if constexpr (std::is_same_v<T, uint64_t>) {
+    return XLA_FFI_DataType_U64;
+  } else if constexpr (std::is_same_v<T, float>) {
+    return XLA_FFI_DataType_F32;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return XLA_FFI_DataType_F64;
+  } else if constexpr (std::is_same_v<T, std::complex<float>>) {
+    return XLA_FFI_DataType_C64;
+  } else {
+    static_assert(std::is_same_v<T, std::complex<double>>,
+                  "unsupported FFI data type");
+    return XLA_FFI_DataType_C128;
+  }
+}
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Binding variadic template defines FFI handler signature
+//===----------------------------------------------------------------------===//
+
+template <ExecutionStage stage, typename... Ts>
+class Binding {
+ public:
+  template <typename T>
+  Binding<stage, Ts..., internal::ArgTag<T>> Arg() && {
+    static_assert(!internal::HasOptionalArgTag<Ts...>::value,
+                  "argument can't be passed after optional argument");
+    static_assert(!internal::HasRemainingArgsTag<Ts...>::value,
+                  "argument can't be passed after remaining arguments");
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::RetTag<T>> Ret() && {
+    static_assert(!internal::HasOptionalRetTag<Ts...>::value,
+                  "result can't be passed after optional result");
+    static_assert(!internal::HasRemainingRetsTag<Ts...>::value,
+                  "result can't be passed after remaining results");
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::OptionalArgTag<T>> OptionalArg() && {
+    static_assert(
+        !internal::HasRemainingArgsTag<Ts...>::value,
+        "optional argument can't be passed after remaining arguments");
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::OptionalRetTag<T>> OptionalRet() && {
+    static_assert(!internal::HasRemainingRetsTag<Ts...>::value,
+                  "optional result can't be passed after remaining results");
+    return {std::move(*this)};
+  }
+
+  Binding<stage, Ts..., internal::RemainingArgsTag> RemainingArgs() && {
+    static_assert(!internal::HasRemainingArgsTag<Ts...>::value,
+                  "remaining arguments can be passed just once");
+    return {std::move(*this)};
+  }
+
+  Binding<stage, Ts..., internal::RemainingRetsTag> RemainingRets() && {
+    static_assert(!internal::HasRemainingRetsTag<Ts...>::value,
+                  "remaining results can be passed just once");
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::CtxTag<T>> Ctx() && {
+    return {std::move(*this)};
+  }
+
+  Binding<stage, Ts..., internal::CtxTag<Context>> Ctx() && {
+    return {std::move(*this)};
+  }
+
+  template <typename T>
+  Binding<stage, Ts..., internal::AttrTag<T>> Attr(std::string attr) && {
+    static_assert(internal::NumTagged<internal::AttrsTag, Ts...>::value == 0,
+                  "dictionary attributes can't be mixed with regular ones");
+    attrs_.push_back(std::move(attr));
+    return {std::move(*this)};
+  }
+
+  template <typename T = Dictionary>
+  Binding<stage, Ts..., internal::AttrsTag<T>> Attrs() && {
+    static_assert(internal::NumTagged<internal::AttrTag, Ts...>::value == 0,
+                  "dictionary attributes can't be mixed with regular ones");
+    return {std::move(*this)};
+  }
+
+  template <typename Fn>
+  std::unique_ptr<Handler<stage, Fn, Ts...>> To(
+      Fn fn, std::initializer_list<Traits> traits = {}) {
+    return std::unique_ptr<Handler<stage, Fn, Ts...>>(
+        new Handler<stage, Fn, Ts...>(std::move(fn), traits, attrs_));
+  }
+
+ private:
+  template <ExecutionStage, typename...>
+  friend class Binding;
+  friend class Ffi;
+
+  explicit Binding() {
+    static_assert(sizeof...(Ts) == 0, "arguments must be empty");
+  }
+
+  template <typename... TTs>
+  Binding(Binding<stage, TTs...>&& other)  // NOLINT
+      : attrs_(std::move(other.attrs_)) {}
+
+  Binding(Binding&) = delete;
+
+  std::vector<std::string> attrs_;  // names of bound attributes
+};
+
+template <ExecutionStage stage>
+Binding<stage> Ffi::Bind() {
+  return xla::ffi::Binding<stage>();
+}
+
+inline Binding<ExecutionStage::kInstantiate> Ffi::BindInstantiate() {
+  return Bind<ExecutionStage::kInstantiate>();
+}
+
+inline Binding<ExecutionStage::kPrepare> Ffi::BindPrepare() {
+  return Bind<ExecutionStage::kPrepare>();
+}
+
+inline Binding<ExecutionStage::kInitialize> Ffi::BindInitialize() {
+  return Bind<ExecutionStage::kInitialize>();
+}
+
+inline Binding<ExecutionStage::kExecute> Ffi::BindExecute() {
+  return Bind<ExecutionStage::kExecute>();
+}
+
+//===----------------------------------------------------------------------===//
+// Template metaprograming to automatically infer Binding from invocable
+// object.
+//===----------------------------------------------------------------------===//
+
+// A little bit of metaprograming that automatically infers the binding schema
+// from an invocable type signature.
+
+// XLA FFI binding for an argument.
+//
+// Example: binding for the `MyType` argument
+//
+//   template <>
+//   struct ArgBinding<MyType> {
+//     using Arg = MyType;
+//   };
+//
+template <typename T>
+struct ArgBinding {
+  using Arg = void;
+};
+
+// XLA FFI binding for a returned result.
+//
+// Example: binding for the `MyType` result
+//
+//   template <>
+//   struct RetBinding<MyType> {
+//     using Ret = MyType;
+//   };
+//
+template <typename T>
+struct RetBinding {
+  using Ret = void;
+};
+
+// XLA FFI binding for a named attribute.
+//
+// Example: binding for the `MyType` attribute
+//
+//   template <>
+//   struct AttrBinding<MyAttr> {
+//     using Attr = MyAttr;
+//     static constexpr std::string_view name() { return "my_attr"; }
+//   };
+//
+template <typename T>
+struct AttrBinding {
+  using Attr = void;
+};
+
+// XLA FFI binding for dictionary attributes: automatic parsing of all
+// attributes into user defined struct.
+template <typename T>
+struct AttrsBinding {
+  using Attrs = void;
+};
+
+// XLA FFI binding for values passed via context.
+//
+// Example: binding for the `gpuStream_t` platform stream
+//
+//   template <>
+//   struct CtxBinding<gpuStream_t> {
+//     using Ctx = PlatformStream<gpuStream_t>;
+//   };
+//
+template <typename T>
+struct CtxBinding {
+  using Ctx = void;
+};
+
+namespace internal {
+
+template <typename Param>
+inline constexpr bool is_arg_binding_v =
+    !std::is_void_v<typename ArgBinding<Param>::Arg>;
+
+template <typename Param>
+inline constexpr bool is_ret_binding_v =
+    !std::is_void_v<typename RetBinding<Param>::Ret>;
+
+template <typename Param>
+inline constexpr bool is_attr_binding_v =
+    !std::is_void_v<typename AttrBinding<Param>::Attr>;
+
+template <typename Param>
+inline constexpr bool is_attrs_binding_v =
+    !std::is_void_v<typename AttrsBinding<Param>::Attrs>;
+
+template <typename Param>
+inline constexpr bool is_ctx_binding_v =
+    !std::is_void_v<typename CtxBinding<Param>::Ctx>;
+
+// A helper template to bind `Params` to `Fn` one by one.
+template <typename Fn, typename... Params>
+struct BindOne;
+
+// A specialization that binds one parameter.
+template <typename Fn, typename Param, typename... Params>
+struct BindOne<Fn, Param, Params...> {
+  // Binds single parameter and then continues with remaining parameters using
+  // recursive template instantiation.
+  template <typename InFlightBinding>
+  static auto To(Fn fn, InFlightBinding binding,
+                 std::initializer_list<Traits> traits) {
+    if constexpr (is_arg_binding_v<Param>) {
+      // Bind parameter as an FFI handler argument.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding).template Arg<typename ArgBinding<Param>::Arg>(),
+          traits);
+
+    } else if constexpr (is_ret_binding_v<Param>) {
+      // Bind parameter as an FFI handler result.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding).template Ret<typename RetBinding<Param>::Ret>(),
+          traits);
+
+    } else if constexpr (is_attr_binding_v<Param>) {
+      // Bind parameter as a named FFI handler attribute.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding).template Attr<typename AttrBinding<Param>::Attr>(
+              std::string(AttrBinding<Param>::name())),
+          traits);
+
+    } else if constexpr (is_attrs_binding_v<Param>) {
+      // Bind parameter as attributes dictionary.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding)
+              .template Attrs<typename AttrsBinding<Param>::Attrs>(),
+          traits);
+
+    } else if constexpr (is_ctx_binding_v<Param>) {
+      // Bind parameter as an FFI handler context.
+      return BindOne<Fn, Params...>::To(
+          std::move(fn),
+          std::move(binding).template Ctx<typename CtxBinding<Param>::Ctx>(),
+          traits);
+
+    } else {
+      // Parameter is not recognized as one of the types that can be bound to
+      // FFI handler.
+      static_assert(sizeof(Param) == 0,
+                    "parameter is not supported for binding");
+    }
+  }
+};
+
+// A specialization that binds `Fn` after consuming all parameters.
+template <typename Fn>
+struct BindOne<Fn> {
+  template <typename InFlightBinding>
+  static auto To(Fn fn, InFlightBinding binding,
+                 std::initializer_list<Traits> traits) {
+    return binding.To(std::move(fn), traits);
+  }
+};
+
+template <ExecutionStage stage, typename Fn>
+struct Bind;
+
+// Binding specialization for function pointers (and captureless lambdas that
+// can be casted to function pointers).
+template <ExecutionStage stage, typename ResultType, typename... Params>
+struct Bind<stage, ResultType (*)(Params...)> {
+  using Fn = ResultType (*)(Params...);
+
+  static auto To(Fn fn, std::initializer_list<Traits> traits) {
+    return BindOne<Fn, Params...>::To(std::move(fn), Ffi::Bind<stage>(),
+                                      traits);
+  }
+};
+
+// Binding specialization for callables (lambdas with captures).
+template <ExecutionStage stage, typename ResultType, typename Fn,
+          typename... Params>
+struct Bind<stage, ResultType (Fn::*)(Params...) const> {
+  static auto To(Fn fn, std::initializer_list<Traits> traits) {
+    return BindOne<Fn, Params...>::To(std::move(fn), Ffi::Bind<stage>(),
+                                      traits);
+  }
+};
+
+}  // namespace internal
+
+template <typename Fn, ExecutionStage stage>
+auto Ffi::BindTo(Fn fn, std::initializer_list<Traits> traits) {
+  if constexpr (std::is_pointer_v<Fn>) {
+    return internal::Bind<stage, Fn>::To(fn, traits);
+  } else {
+    return internal::Bind<stage, decltype(&Fn::operator())>::To(std::move(fn),
+                                                                traits);
+  }
+}
+
+// A container for defining parameters corresponding to results.
+template <typename T>
+class Result {
+ public:
+  Result(T value) : value_(value) {}  // NOLINT
+  T& operator*() { return value_; }
+  T* operator->() { return &value_; }
+
+ private:
+  T value_;
+};
+
+// A container for defining parameters corresponding to attributes with an
+// attribute name available as compile time value.
+template <typename T, char const* attr_name>
+class Attr {
+ public:
+  Attr(T value) : value_(value) {}  // NOLINT
+  T& operator*() { return value_; }
+  T* operator->() { return &value_; }
+
+ private:
+  T value_;
+};
+
+//===----------------------------------------------------------------------===//
+// Attributes bindings
+//===----------------------------------------------------------------------===//
+
+// Default attribute binding for `Attr` parameters.
+template <typename T, const char* attr_name>
+struct AttrBinding<Attr<T, attr_name>> {
+  using Attr = T;
+  static constexpr std::string_view name() { return attr_name; }
+};
+
+// Default attributes binding for `Dictionary` parameters.
+template <>
+struct AttrsBinding<Dictionary> {
+  using Attrs = Dictionary;
+};
+
+//===----------------------------------------------------------------------===//
+// Arguments decoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI arguments decoding must be defined by specializing this template.
+//
+// Example: decoding for the `MyType` arguments
+//
+//   template <>
+//   struct ArgDecoding<MyType> {
+//     static bool Isa(XLA_FFI_ArgType type, void* arg);
+//     static std::optional<MyType> Decode(XLA_FFI_ArgType type, void* arg);
+//   };
+//
+// If argument can't be decoded it should return the empty optional.
+template <typename T>
+struct ArgDecoding;
+
+//===----------------------------------------------------------------------===//
+// Results decoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI results decoding must be defined by specializing this template.
+//
+// Example: decoding for the `MyType` results
+//
+//   template <>
+//   struct RetDecoding<MyType> {
+//     static bool Isa(XLA_FFI_RetType type, void* ret);
+//     static std::optional<MyType> Decode(XLA_FFI_RetType type, void* ret);
+//   };
+//
+// If argument can't be decoded it should return the empty optional.
+template <typename T>
+struct RetDecoding;
+
+//===----------------------------------------------------------------------===//
+// Attributes decoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI attribute decoding must be defined by specializing this template.
+//
+// Example: decoding for the `MyType` attributes
+//
+//   template <>
+//   struct AttrDecoding<MyType> {
+//     using Type = <handler argument type for attribute type MyType>
+//     static bool Isa(XLA_FFI_AttrType type, void* attr);
+//     static std::optional<MyType> Decode(XLA_FFI_AttrType type, void* attr,
+//                                         DiagnosticEngine&);
+//   }
+//
+template <typename T>
+struct AttrDecoding;
+
+//===----------------------------------------------------------------------===//
+// Context decoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI execution context decoding must be defined by specializing this
+// template.
+//
+// Example: decoding for the `MyType` context
+//
+//   template <>
+//   struct CtxDecoding<MyType> {
+//    using Type = <handler argument type for context type MyType>;
+//    static std::optional<Type> Decode(const XLA_FFI_Api* api,
+//                                      XLA_FFI_ExecutionContext* ctx);
+//   }
+//
+template <typename T>
+struct CtxDecoding;
+
+//===----------------------------------------------------------------------===//
+// Result encoding implementation
+//===----------------------------------------------------------------------===//
+
+// XLA FFI result encoding (conversion from a returned status-like type to FFI
+// error type) must be defined by specializing this template.
+//
+// Example: encoding `absl::Status` result
+//
+//   template<ExecutionStage stage>
+//   struct ResultEncoding<stage, absl::Status> {
+//     XLA_FFI_Error* Encode(const XLA_FFI_Api* api,
+//                           XLA_FFI_ExecutionContext* ctx,
+//                           absl::Status status) {...}
+//   };
+//
+// Result encoding is execution stage specific, for example at instantiation
+// stage FFI handler can return an FFI handler state, while at execution stage
+// we only support returning a status-like type.
+//
+// Asynchronous FFI handlers can return encoded result as an `XLA_FFI_Future*`
+// or as an `std::variant` of `XLA_FFI_Error*` and `XLA_FFI_Future*`, where an
+// error can be used to return synchronous errors (i.e., invalid arguments), and
+// a future can be used to return asynchronous completion. See example of such
+// encoding in result encoding for `Future`.
+//
+// Example: encoding `xla::ffi::Future` result
+//
+//   template<ExecutionStage stage>
+//   struct ResultEncoding<state, xla::ffi::Future> {
+//     std::variant<XLA_FFI_Error*, XLA_FFI_Future*> Encode(
+//       const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+//       xla::ffi::Future future) {...}
+//   };
+//
+template <ExecutionStage stage, typename T>
+struct ResultEncoding;
+
+//===----------------------------------------------------------------------===//
+// Diagnostics
+//===----------------------------------------------------------------------===//
+
+class DiagnosticEngine;
+
+// RAII wrapper around constructed, but but not yet emitted diagnostic. In
+// flight diagnostic gives an opportunity to build a diagnostic before reporting
+// it to the engine, similar to the builder pattern.
+class InFlightDiagnostic {
+ public:
+  explicit InFlightDiagnostic(DiagnosticEngine* engine, std::string s)
+      : engine_(engine) {
+    stream_ << s;
+  }
+  InFlightDiagnostic(const InFlightDiagnostic&) = delete;
+  InFlightDiagnostic& operator=(const InFlightDiagnostic&) = delete;
+
+  ~InFlightDiagnostic();
+
+  template <typename Arg>
+  InFlightDiagnostic& operator<<(Arg&& arg) {
+    stream_ << std::forward<Arg>(arg);
+    return *this;
+  }
+
+  template <typename T>
+  operator std::optional<T>() const {  // NOLINT
+    return std::nullopt;
+  }
+
+ private:
+  DiagnosticEngine* engine_;
+  std::stringstream stream_;
+};
+
+class DiagnosticEngine {
+ public:
+  DiagnosticEngine() = default;
+  DiagnosticEngine(const DiagnosticEngine&) = delete;
+  DiagnosticEngine& operator=(const DiagnosticEngine&) = delete;
+
+  InFlightDiagnostic Emit(std::string message) {
+    return InFlightDiagnostic(this, std::move(message));
+  }
+
+  std::string Result() const { return acc_; }
+
+ private:
+  friend class InFlightDiagnostic;
+
+  void append(std::string s) { acc_.append(std::move(s)); }
+
+  std::string acc_;
+};
+
+inline InFlightDiagnostic::~InFlightDiagnostic() {
+  engine_->append(stream_.str());
+}
+
+//===----------------------------------------------------------------------===//
+// Decoding arguments and attributes
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+// When decoding input data we need to keep track of how many arguments and
+// attributes we decoded so far to compute call frame offsets.
+struct DecodingOffsets {
+  int64_t args = 0;
+  int64_t rets = 0;
+  int64_t attrs = 0;
+};
+
+struct DecodingContext {
+  XLA_FFI_CallFrame* call_frame;
+
+  const std::string* attrs_names;  // not owned
+  const std::size_t* attrs_idx;    // not owned
+};
+
+template <typename T>
+struct Decode;
+
+template <typename T>
+struct Decode<ArgTag<T>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<T> call(DecodingOffsets& offsets, DecodingContext& ctx,
+                               DiagnosticEngine& diagnostic) {
+    int64_t idx = offsets.args++;
+    return ArgDecoding<T>::Decode(ctx.call_frame->args.types[idx],
+                                  ctx.call_frame->args.args[idx], diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<OptionalArgTag<T>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<std::optional<T>> call(DecodingOffsets& offsets,
+                                              DecodingContext& ctx,
+                                              DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(offsets.args >= ctx.call_frame->args.size)) {
+      return std::optional<T>(std::nullopt);
+    }
+    return Decode<ArgTag<T>>::call(offsets, ctx, diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<RetTag<T>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Result<T>> call(DecodingOffsets& offsets,
+                                       DecodingContext& ctx,
+                                       DiagnosticEngine& diagnostic) {
+    int64_t idx = offsets.rets++;
+    return RetDecoding<T>::Decode(ctx.call_frame->rets.types[idx],
+                                  ctx.call_frame->rets.rets[idx], diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<OptionalRetTag<T>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<std::optional<Result<T>>> call(
+      DecodingOffsets& offsets, DecodingContext& ctx,
+      DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(offsets.rets >= ctx.call_frame->rets.size)) {
+      return std::optional<Result<T>>(std::nullopt);
+    }
+    return Decode<RetTag<T>>::call(offsets, ctx, diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<AttrTag<T>> {
+  using R = typename AttrDecoding<T>::Type;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<R> call(DecodingOffsets& offsets, DecodingContext& ctx,
+                               DiagnosticEngine& diagnostic) {
+    // Find decoded attribute corresponding to the given attribute index.
+    int64_t i = offsets.attrs++;
+
+    // Get mapping from the attribute to its index in the sorted array.
+    size_t idx = ctx.attrs_idx[i];
+
+    // Load attribute from call frame using index into the sorted array.
+    XLA_FFI_AttrType attr_type = ctx.call_frame->attrs.types[idx];
+    XLA_FFI_ByteSpan* attr_name = ctx.call_frame->attrs.names[idx];
+    void* attr = ctx.call_frame->attrs.attrs[idx];
+
+    // We use a handwritten string comparison function because calling builtin
+    // string compare function adds a function call overhead on a hot path, and
+    // we expect all attribute names to be short and equal.
+    auto eq = [](XLA_FFI_ByteSpan* a, std::string_view b) {
+      if (XLA_FFI_PREDICT_FALSE(a->len != b.size())) {
+        return false;
+      }
+      for (size_t i = 0; i < a->len; ++i) {
+        if (XLA_FFI_PREDICT_FALSE(a->ptr[i] != b.data()[i])) {
+          return false;
+        }
+      }
+      return true;
+    };
+
+    // TODO(ezhulenev): Currently we require that attributes passed to the FFI
+    // handler must match attributes referenced in a binding, however
+    // we could safely ignore extra attributes. Relax this if needed.
+    if (XLA_FFI_PREDICT_FALSE(!eq(attr_name, ctx.attrs_names[i]))) {
+      return diagnostic.Emit("Attribute name mismatch: ")
+             << std::string_view{attr_name->ptr, attr_name->len} << " vs "
+             << ctx.attrs_names[i];
+    }
+
+    return AttrDecoding<T>::Decode(attr_type, attr, diagnostic);
+  }
+};
+
+template <typename T>
+struct Decode<CtxTag<T>> {
+  using R = typename CtxDecoding<T>::Type;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<R> call(DecodingOffsets& offsets, DecodingContext& ctx,
+                               DiagnosticEngine& diagnostic) {
+    return CtxDecoding<T>::Decode(ctx.call_frame->api, ctx.call_frame->ctx,
+                                  diagnostic);
+  }
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing a variable number of arguments.
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+class RemainingArgsBase {
+ public:
+  RemainingArgsBase(const XLA_FFI_Args* args, size_t offset)
+      : args_(args), offset_(offset) {
+    assert(offset <= args_->size && "illegal remaining args offset");
+  }
+
+  template <typename T>
+  bool isa(size_t index) const {
+    size_t idx = offset() + index;
+    assert(idx < args_->size && "illegal remaining args index");
+    return ArgDecoding<T>::Isa(args_->types[idx], args_->args[idx]);
+  }
+
+  size_t size() const { return args_->size - offset_; }
+  bool empty() const { return size() == 0; }
+
+ protected:
+  const XLA_FFI_Args* args() const { return args_; }
+  size_t offset() const { return offset_; }
+
+ private:
+  const XLA_FFI_Args* args_;
+  size_t offset_;
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing a variable number of results.
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+class RemainingRetsBase {
+ public:
+  RemainingRetsBase(const XLA_FFI_Rets* rets, size_t offset)
+      : rets_(rets), offset_(offset) {
+    assert(offset <= rets_->size && "illegal remaining rets offset");
+  }
+
+  template <typename T>
+  bool isa(size_t index) const {
+    size_t idx = offset_ + index;
+    assert(idx < rets_->size && "illegal remaining rets index");
+    return RetDecoding<T>::Isa(rets_->types[idx], rets_->rets[idx]);
+  }
+
+  size_t size() const { return rets_->size - offset_; }
+  bool empty() const { return size() == 0; }
+
+ protected:
+  const XLA_FFI_Rets* rets() const { return rets_; }
+  size_t offset() const { return offset_; }
+
+ private:
+  const XLA_FFI_Rets* rets_;  // not owned
+  size_t offset_;
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing dictionary attributes.
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+// Forward declare dictionary attribute decoding defined below.
+template <typename T, typename... Ts>
+struct DecodeDictionaryAttr;
+
+class DictionaryBase {
+ public:
+  explicit DictionaryBase(const XLA_FFI_Attrs* attrs) : attrs_(attrs) {}
+
+  // Iterator for iterating over dictionary attribute names.
+  class Iterator {
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = ptrdiff_t;
+    using value_type = std::string_view;
+
+    bool operator==(const Iterator& it) const { return idx_ == it.idx_; }
+    bool operator!=(const Iterator& it) const { return idx_ != it.idx_; }
+
+    std::string_view operator*() const {
+      return std::string_view{attrs_->names[idx_]->ptr,
+                              attrs_->names[idx_]->len};
+    }
+
+    Iterator& operator++() {
+      ++idx_;
+      return *this;
+    }
+
+   private:
+    friend class DictionaryBase;
+    Iterator(const XLA_FFI_Attrs* attrs, size_t idx)
+        : attrs_(attrs), idx_(idx) {}
+
+    const XLA_FFI_Attrs* attrs_;
+    size_t idx_ = 0;
+  };
+
+  size_t size() const { return attrs_->size; }
+
+  bool contains(std::string_view name) const { return Find(name).has_value(); }
+
+  Iterator begin() const { return Iterator(attrs_, 0); }
+  Iterator end() const { return Iterator(attrs_, size()); }
+
+  template <typename T>
+  bool contains(std::string_view name) const {
+    std::optional<size_t> idx = Find(name);
+    if (XLA_FFI_PREDICT_FALSE(!idx.has_value())) {
+      return false;
+    }
+
+    XLA_FFI_AttrType attr_type = attrs_->types[*idx];
+    void* attr = attrs_->attrs[*idx];
+    return AttrDecoding<T>::Isa(attr_type, attr);
+  }
+
+  template <typename T>
+  bool isa(const Iterator& it) const {
+    XLA_FFI_AttrType attr_type = attrs_->types[it.idx_];
+    void* attr = attrs_->attrs[it.idx_];
+    return AttrDecoding<T>::Isa(attr_type, attr);
+  }
+
+ protected:
+  template <typename T, typename... Ts>
+  friend struct DecodeDictionaryAttr;
+
+  template <typename T>
+  std::optional<size_t> get(const Iterator& it,
+                            DiagnosticEngine& diagnostic) const {
+    XLA_FFI_AttrType attr_type = attrs_->types[it.idx_];
+    void* attr = attrs_->attrs[it.idx_];
+    return AttrDecoding<T>::Decode(attr_type, attr, diagnostic);
+  }
+
+  template <typename T>
+  std::optional<T> get(std::string_view name,
+                       DiagnosticEngine& diagnostic) const {
+    std::optional<size_t> idx = Find(name);
+    if (XLA_FFI_PREDICT_FALSE(!idx.has_value())) {
+      return diagnostic.Emit("Unexpected attribute: ") << name;
+    }
+
+    XLA_FFI_AttrType attr_type = attrs_->types[*idx];
+    void* attr = attrs_->attrs[*idx];
+    return AttrDecoding<T>::Decode(attr_type, attr, diagnostic);
+  }
+
+ private:
+  std::optional<size_t> Find(std::string_view name) const {
+    XLA_FFI_ByteSpan** begin = attrs_->names;
+    XLA_FFI_ByteSpan** end = begin + attrs_->size;
+
+    auto eq = [](XLA_FFI_ByteSpan* a, std::string_view b) {
+      return std::string_view{a->ptr, a->len} == b;
+    };
+
+    auto lt = [](XLA_FFI_ByteSpan* a, std::string_view b) {
+      return std::string_view{a->ptr, a->len} < b;
+    };
+
+    // Lower bound can be `end` if the attribute is not found, or the first
+    // attribute not ordered before the `name`.
+    auto lower_bound = std::lower_bound(begin, end, name, lt);
+    return lower_bound == end || !eq(*lower_bound, name)
+               ? std::nullopt
+               : std::make_optional(std::distance(begin, lower_bound));
+  }
+
+  const XLA_FFI_Attrs* attrs_;
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Decoding for aggregate attributes (decoding dictionaries into structs).
+//===----------------------------------------------------------------------===//
+
+// Decode `AttrsTag` into a type `T` relying on struct decoding defined below.
+template <typename T>
+struct internal::Decode<internal::AttrsTag<T>> {
+  static std::optional<T> call(DecodingOffsets& offsets, DecodingContext& ctx,
+                               DiagnosticEngine& diagnostic) {
+    return AttrDecoding<T>::Decode(XLA_FFI_AttrType_DICTIONARY,
+                                   &ctx.call_frame->attrs, diagnostic);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing context.
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+class ContextBase {
+ public:
+  ContextBase(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx)
+      : api_(api), ctx_(ctx) {}
+
+  const XLA_FFI_Api* api() const { return api_; }
+  XLA_FFI_ExecutionContext* ctx() const { return ctx_; }
+
+ protected:
+  template <typename T>
+  std::optional<typename CtxDecoding<T>::Type> get(
+      DiagnosticEngine& diagnostic) const {
+    return CtxDecoding<T>::Decode(api_, ctx_, diagnostic);
+  }
+
+ private:
+  const XLA_FFI_Api* api_;
+  XLA_FFI_ExecutionContext* ctx_;
+};
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Template metaprograming for decoding handler signature
+//===----------------------------------------------------------------------===//
+
+// Forward declare classes for decoding variadic number of arguments and
+// results. They are defined in `ffi.h` headers (internal and external), to be
+// able to use slightly different implementations for internal and external
+// FFI (`absl::StatusOr` vs `ffi::ErrorOr`).
+class RemainingArgs;
+class RemainingRets;
+
+namespace internal {
+// A helper struct to extract the type of the handler argument.
+template <typename T>
+struct FnArgType;
+
+template <typename T>
+struct FnArgType<internal::ArgTag<T>> {
+  using Type = T;
+};
+
+template <typename T>
+struct FnArgType<internal::OptionalArgTag<T>> {
+  using Type = std::optional<T>;
+};
+
+template <>
+struct FnArgType<internal::RemainingArgsTag> {
+  using Type = RemainingArgs;
+};
+
+template <typename T>
+struct FnArgType<internal::RetTag<T>> {
+  using Type = Result<T>;
+};
+
+template <typename T>
+struct FnArgType<internal::OptionalRetTag<T>> {
+  using Type = std::optional<Result<T>>;
+};
+
+template <>
+struct FnArgType<internal::RemainingRetsTag> {
+  using Type = RemainingRets;
+};
+
+template <typename T>
+struct FnArgType<internal::AttrTag<T>> {
+  using Type = typename AttrDecoding<T>::Type;
+};
+
+template <typename T>
+struct FnArgType<internal::AttrsTag<T>> {
+  using Type = T;
+};
+
+template <typename T>
+struct FnArgType<internal::CtxTag<T>> {
+  using Type = typename CtxDecoding<T>::Type;
+};
+
+// A template to detect result encodings that are state constructors. We use
+// this to report back the TypeId of the state as a part of the metadata.
+template <typename ResultEncoding, typename = void>
+struct IsStateConstructor : std::false_type {};
+
+// Check if the ResultEncoding has a static `state_type_id(const XLA_FFI_Api*)`
+// method returning the XLA_FFI_TypeId.
+template <typename ResultEncoding>
+struct IsStateConstructor<
+    ResultEncoding,
+    std::enable_if_t<std::is_same_v<XLA_FFI_TypeId,
+                                    decltype(ResultEncoding::state_type_id(
+                                        std::declval<const XLA_FFI_Api*>()))>>>
+    : std::true_type {};
+
+template <typename ResultEncoding>
+static constexpr bool is_state_constructor_v =  // NOLINT
+    IsStateConstructor<ResultEncoding>::value;
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Handler decodes FFI call frame and invokes `Fn` with decoded arguments
+//===----------------------------------------------------------------------===//
+
+template <ExecutionStage stage, typename Fn, typename... Ts>
+class Handler : public Ffi {
+  static constexpr int64_t kSize = sizeof...(Ts);
+
+  static constexpr int64_t kNumArgs =
+      internal::NumTagged<internal::ArgTag, Ts...>::value;
+
+  static constexpr int64_t kNumOptionalArgs =
+      internal::NumTagged<internal::OptionalArgTag, Ts...>::value;
+
+  static constexpr int64_t kNumRets =
+      internal::NumTagged<internal::RetTag, Ts...>::value;
+
+  static constexpr int64_t kNumOptionalRets =
+      internal::NumTagged<internal::OptionalRetTag, Ts...>::value;
+
+  static constexpr int64_t kNumAttrs =
+      internal::NumTagged<internal::AttrTag, Ts...>::value;
+
+  static constexpr int64_t kNumDictAttrs =
+      internal::NumTagged<internal::AttrsTag, Ts...>::value;
+
+  static_assert(kNumAttrs == 0 || kNumDictAttrs == 0,
+                "dictionary attributes can't be mixed with regular ones");
+
+  template <typename T>
+  using FnArgType = typename internal::FnArgType<T>::Type;
+
+  static_assert(std::is_invocable_v<Fn, FnArgType<Ts>...>,
+                "FFI binding signature is not compatible with a function type");
+
+  using ResultType = std::invoke_result_t<Fn, FnArgType<Ts>...>;
+
+ public:
+  // Note: this function is on a hot path, any any attempt to split it leads to
+  // measurable regressions in microbenchmarks. It is a straight line block of
+  // mostly constexpr conditionals, that gets optimized to a much smaller code
+  // size in all template instantiations.
+  XLA_FFI_Error* Call(XLA_FFI_CallFrame* call_frame) const override {
+    // Sanity checking call frame struct size.
+    if (XLA_FFI_Error* err = CheckStructSize(
+            call_frame->api, "XLA_FFI_CallFrame", XLA_FFI_CallFrame_STRUCT_SIZE,
+            call_frame->struct_size);
+        XLA_FFI_PREDICT_FALSE(err)) {
+      return err;
+    }
+
+    // If passed a call frame with the metadata extension, just return the
+    // metadata.
+    if (XLA_FFI_PREDICT_FALSE(call_frame->extension_start != nullptr &&
+                              call_frame->extension_start->type ==
+                                  XLA_FFI_Extension_Metadata)) {
+      return PopulateMetadata(call_frame->api,
+                              reinterpret_cast<XLA_FFI_Metadata_Extension*>(
+                                  call_frame->extension_start));
+    }
+
+    // Check that handler is called during correct execution stage.
+    if (XLA_FFI_PREDICT_FALSE(call_frame->stage !=
+                              static_cast<XLA_FFI_ExecutionStage>(stage))) {
+      return InvalidArgument(call_frame->api,
+                             StrCat("Wrong execution stage: expected `",
+                                    static_cast<XLA_FFI_ExecutionStage>(stage),
+                                    "` but got `", call_frame->stage, "`"));
+    }
+
+    // Check that the number of passed arguments matches the signature. Each
+    // individual argument decoding will check the actual type.
+    if constexpr (internal::HasRemainingArgsTag<Ts...>::value) {
+      if (XLA_FFI_PREDICT_FALSE(call_frame->args.size < kNumArgs)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of arguments: expected at least ",
+                   kNumArgs - kNumOptionalArgs - 1, " but got ",
+                   call_frame->args.size));
+      }
+    } else if constexpr (internal::HasOptionalArgTag<Ts...>::value) {
+      if (XLA_FFI_PREDICT_FALSE(call_frame->args.size < kNumArgs)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of arguments: expected at least ",
+                   kNumArgs - kNumOptionalArgs, " but got ",
+                   call_frame->args.size));
+      }
+    } else {
+      // It is safe to not check the number of arguments if we don't plan to
+      // decode any of them, i.e. for prepare/initialize stages where the FFI
+      // handler might be interested only in the attributes or context.
+      if (XLA_FFI_PREDICT_FALSE(call_frame->args.size != kNumArgs &&
+                                kNumArgs > 0)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of arguments: expected ", kNumArgs,
+                   " but got ", call_frame->args.size));
+      }
+    }
+
+    // Check that the number of results matches the signature. Each individual
+    // result decoding will check the actual type.
+    if constexpr (internal::HasRemainingRetsTag<Ts...>::value) {
+      if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size < kNumRets)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of results: expected at least ",
+                   kNumRets - kNumOptionalRets - 1, " but got ",
+                   call_frame->rets.size));
+      }
+    } else if constexpr (internal::HasOptionalRetTag<Ts...>::value) {
+      if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size < kNumRets)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of results: expected at least ",
+                   kNumRets - kNumOptionalRets, " but got ",
+                   call_frame->rets.size));
+      }
+    } else {
+      // It is safe to not check the number of results if we don't plan to
+      // decode any of them, i.e. for prepare/initialize stages where the FFI
+      // handler might be interested only in the attributes or context.
+      if (XLA_FFI_PREDICT_FALSE(call_frame->rets.size != kNumRets &&
+                                kNumRets > 0)) {
+        return InvalidArgument(
+            call_frame->api,
+            StrCat("[", call_frame->stage, "] ",
+                   "Wrong number of results: expected ", kNumRets, " but got ",
+                   call_frame->rets.size));
+      }
+    }
+
+    // Check that the number of passed attributes matches the signature. Each
+    // individual attribute decoding will check the actual type.
+    //
+    // If we decode attributes into a dictionary (or a custom struct decoded
+    // from a dictionary), then there is no need to check the number of
+    // attributes, as the FFI handler (or a struct decoding) should be
+    // responsible for it.
+    //
+    // If the number of bound attributes is zero, then we also don't care about
+    // the number of attributes in the call frame. FFI handler can safely choose
+    // to ignore attributes in this case. We only need to check the number of
+    // attributes if we plan to decode them, as we build a mapping from the
+    // attribute name to its index in the call frame attributes.
+    if (XLA_FFI_PREDICT_FALSE(kNumDictAttrs == 0 && kNumAttrs > 0 &&
+                              call_frame->attrs.size != kNumAttrs)) {
+      std::stringstream msg;
+      msg << "[" << call_frame->stage << "] "
+          << "Wrong number of attributes: expected " << kNumAttrs << " but got "
+          << call_frame->attrs.size;
+      if (call_frame->attrs.size > 0) {
+        msg << " with name(s): ";
+        for (int64_t n = 0; n < call_frame->attrs.size - 1; ++n) {
+          msg << std::string_view(call_frame->attrs.names[n]->ptr,
+                                  call_frame->attrs.names[n]->len)
+              << ", ";
+        }
+        msg << std::string_view(
+            call_frame->attrs.names[call_frame->attrs.size - 1]->ptr,
+            call_frame->attrs.names[call_frame->attrs.size - 1]->len);
+      }
+      return InvalidArgument(call_frame->api, msg.str());
+    }
+
+    // Define index sequences to access custom call operands.
+    using Is = std::make_index_sequence<kSize>;
+
+    return Call(call_frame, Is{});
+  }
+
+ private:
+  XLA_FFI_Error* PopulateMetadata(const XLA_FFI_Api* api,
+                                  XLA_FFI_Metadata_Extension* extension) const {
+    if (XLA_FFI_Error* err =
+            StructSizeIsGreaterOrEqual(api, "XLA_FFI_Metadata_Extension",
+                                       XLA_FFI_Metadata_Extension_STRUCT_SIZE,
+                                       extension->extension_base.struct_size)) {
+      return err;
+    }
+
+    if (XLA_FFI_Error* err = StructSizeIsGreaterOrEqual(
+            api, "XLA_FFI_Metadata", XLA_FFI_Metadata_STRUCT_SIZE,
+            extension->metadata->struct_size)) {
+      return err;
+    }
+
+    // Set the API version to the version of the FFI headers used by a handler.
+    extension->metadata->api_version = XLA_FFI_Api_Version{
+        XLA_FFI_Api_Version_STRUCT_SIZE,
+        /*extension_start=*/nullptr,
+        XLA_FFI_API_MAJOR,
+        XLA_FFI_API_MINOR,
+    };
+
+    // Collect all traits and store them in the metadata.
+    XLA_FFI_Handler_Traits traits = 0;
+    for (const Traits& trait : traits_) {
+      traits |= static_cast<XLA_FFI_Handler_Traits>(trait);
+    }
+    extension->metadata->traits = traits;
+
+    // Check if the handler creates a new state object and if so, record its
+    // type id in the metadata.
+    using ResultEncoding = ResultEncoding<stage, ResultType>;
+    if constexpr (internal::is_state_constructor_v<ResultEncoding>) {
+      if (ResultEncoding::state_type_id(api) == XLA_FFI_UNKNOWN_TYPE_ID) {
+        return FailedPrecondition(api,
+                                  "Types used by FFI handlers must be "
+                                  "registered before the handler registration");
+      }
+      extension->metadata->state_type_id = ResultEncoding::state_type_id(api);
+    } else {
+      extension->metadata->state_type_id = XLA_FFI_UNKNOWN_TYPE_ID;
+    }
+
+    return Success();
+  }
+
+  template <size_t... Is>
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE XLA_FFI_Error* Call(
+      XLA_FFI_CallFrame* call_frame, std::index_sequence<Is...>) const {
+    // A helper structure to allow each decoder find the correct offset.
+    internal::DecodingOffsets offsets;
+
+    // Package all the data required for decoding ffi handler operands.
+    internal::DecodingContext ctx = {call_frame, attrs_.data(),
+                                     attrs_idx_.data()};
+
+    DiagnosticEngine diagnostic;
+
+    std::tuple<std::optional<FnArgType<Ts>>...> args = {
+        internal::Decode<Ts>::call(offsets, ctx, diagnostic)...};
+
+    if constexpr (sizeof...(Ts) > 0) {
+      // We intentionally use `&`, as it generates fewer branch instructions.
+      bool all_decoded = (std::get<Is>(args).has_value() & ...);
+      if (XLA_FFI_PREDICT_FALSE(!all_decoded)) {
+        return FailedDecodeError(
+            call_frame, {std::get<Is>(args).has_value()...}, diagnostic);
+      }
+    }
+
+    ResultType result = fn_(std::move(*std::get<Is>(args))...);
+    auto encoded = ResultEncoding<stage, ResultType>::Encode(
+        call_frame->api, call_frame->ctx, std::move(result));
+
+    // We do support three kinds of FFI result encodings:
+    //   (1) Synchronous handlers that return result encoded as XLA_FFI_Error*
+    //   (2) Asynchronous handlers that return result encoded as XLA_FFI_Future*
+    //   (3) Handlers that can return either (1) or (2)
+    static constexpr bool kIsEncodedError =
+        std::is_same_v<decltype(encoded), XLA_FFI_Error*>;
+    static constexpr bool kIsEncodedFuture =
+        std::is_same_v<decltype(encoded), XLA_FFI_Future*>;
+    static constexpr bool kIsEncodedErrorOrFuture =
+        std::is_same_v<decltype(encoded),
+                       std::variant<XLA_FFI_Error*, XLA_FFI_Future*>>;
+
+    static_assert(
+        kIsEncodedError || kIsEncodedFuture || kIsEncodedErrorOrFuture,
+        "Unsupported result encoding type");
+
+    if constexpr (kIsEncodedError) {
+      return encoded;
+    }
+
+    if constexpr (kIsEncodedFuture) {
+      call_frame->future = encoded;
+      assert(call_frame->future != nullptr);
+      return nullptr;
+    }
+
+    if constexpr (kIsEncodedErrorOrFuture) {
+      if (encoded.index() == 0) {
+        return std::get<0>(encoded);
+      }
+      call_frame->future = std::get<1>(encoded);
+      assert(call_frame->future != nullptr);
+      return nullptr;
+    }
+
+    std::abort();  // unreachable
+  }
+
+  XLA_FFI_Error* FailedDecodeError(const XLA_FFI_CallFrame* call_frame,
+                                   std::array<bool, kSize> decoded,
+                                   const DiagnosticEngine& diagnostic) const {
+    std::stringstream message;
+    message << "[" << call_frame->stage << "] "
+            << "Failed to decode all FFI handler operands (bad operands at: ";
+    for (size_t cnt = 0, idx = 0; idx < kSize; ++idx) {
+      if (!decoded[idx]) {
+        if (cnt++) {
+          message << ", ";
+        }
+        message << std::to_string(idx);
+      }
+    }
+    message << ")";
+    if (auto s = std::move(diagnostic).Result(); !s.empty()) {
+      message << "\nDiagnostics:\n" << s;
+    }
+    return InvalidArgument(call_frame->api, message.str());
+  }
+
+  template <ExecutionStage, typename...>
+  friend class Binding;
+
+  Handler(Fn fn, std::vector<Traits> traits, std::vector<std::string> attrs)
+      : fn_(std::move(fn)),
+        traits_(std::move(traits)),
+        attrs_(std::move(attrs)) {
+    // Sort attributes' names and remove duplicates. These unique attributes are
+    // what we'll be looking for in the call frame attributes.
+    std::vector<std::string> sorted = attrs_;
+    std::sort(sorted.begin(), sorted.end());
+    sorted.erase(
+        std::unique(sorted.begin(), sorted.end(), std::equal_to<std::string>()),
+        sorted.end());
+
+    // Find index of every attribute in the sorted attributes vector.
+    for (size_t i = 0; i < attrs_.size(); ++i) {
+      attrs_idx_.push_back(std::distance(
+          sorted.begin(),
+          std::find(sorted.begin(), sorted.end(), attrs_[i])));  // NOLINT
+    }
+  }
+
+  Fn fn_;
+  std::vector<Traits> traits_;
+
+  std::vector<std::string> attrs_;  // names of bound attributes
+
+  // A mapping from the attribute index (index into the `attrs_` member) to its
+  // index in the lexicographically sorted vector of attribute names. Call frame
+  // passes attributes sorted by name, and with this index we can find the
+  // attribute we are looking for using O(1) lookup, assuming if the call frame
+  // has exact same attributes as the binding. If not, this allows to do a more
+  // efficient binary search by skipping a part of the call frame attributes.
+  std::vector<size_t> attrs_idx_;
+};
+
+//===----------------------------------------------------------------------===//
+// Builtin attributes decoding
+//===----------------------------------------------------------------------===//
+
+#define XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(T, TYPE)                     \
+  template <>                                                              \
+  struct AttrDecoding<T> {                                                 \
+    using Type = T;                                                        \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static bool Isa(XLA_FFI_AttrType type, \
+                                                    void* attr) {          \
+      return type == XLA_FFI_AttrType_SCALAR &&                            \
+             reinterpret_cast<XLA_FFI_Scalar*>(attr)->dtype == TYPE;       \
+    }                                                                      \
+                                                                           \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<T> Decode(        \
+        XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) { \
+      if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_SCALAR)) {        \
+        return diagnostic.Emit("Wrong attribute type: expected ")          \
+               << XLA_FFI_AttrType_SCALAR << " but got " << type;          \
+      }                                                                    \
+                                                                           \
+      auto* scalar = reinterpret_cast<XLA_FFI_Scalar*>(attr);              \
+      if (XLA_FFI_PREDICT_FALSE(scalar->dtype != TYPE)) {                  \
+        return diagnostic.Emit("Wrong scalar data type: expected ")        \
+               << TYPE << " but got " << scalar->dtype;                    \
+      }                                                                    \
+                                                                           \
+      return *reinterpret_cast<T*>(scalar->value);                         \
+    }                                                                      \
+  }
+
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(bool, XLA_FFI_DataType_PRED);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(int8_t, XLA_FFI_DataType_S8);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(int16_t, XLA_FFI_DataType_S16);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(int32_t, XLA_FFI_DataType_S32);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(int64_t, XLA_FFI_DataType_S64);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(uint8_t, XLA_FFI_DataType_U8);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(uint16_t, XLA_FFI_DataType_U16);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(uint32_t, XLA_FFI_DataType_U32);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(uint64_t, XLA_FFI_DataType_U64);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(float, XLA_FFI_DataType_F32);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(double, XLA_FFI_DataType_F64);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(std::complex<float>,
+                                      XLA_FFI_DataType_C64);
+XLA_FFI_REGISTER_SCALAR_ATTR_DECODING(std::complex<double>,
+                                      XLA_FFI_DataType_C128);
+
+#undef XLA_FFI_REGISTER_SCALAR_ATTR_DECODING
+
+// Decoding for an attribute of `std::variant<T0, T1, Ts...>` type.
+//
+// Returns the decoding result for a first type that matches the attribute type,
+// if no type matches, returns std::nullopt.
+template <typename T0, typename T1, typename... Ts>
+struct AttrDecoding<std::variant<T0, T1, Ts...>> {
+  using Type = std::variant<T0, T1, Ts...>;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static bool Isa(XLA_FFI_AttrType type,
+                                                  void* attr) {
+    return AttrDecoding<T0>::Isa(type, attr) ||
+           AttrDecoding<T1>::Isa(type, attr) ||
+           (AttrDecoding<Ts>::Isa(type, attr) || ...);
+  };
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    return Decode<T0, T1, Ts...>(type, attr, diagnostic);
+  }
+
+ private:
+  template <typename U, typename... Us>
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    if (AttrDecoding<U>::Isa(type, attr)) {
+      if (auto decoded = AttrDecoding<U>::Decode(type, attr, diagnostic);
+          XLA_FFI_PREDICT_TRUE(decoded)) {
+        return std::move(*decoded);
+      }
+      return std::nullopt;
+    }
+
+    if constexpr (sizeof...(Us) > 0) {
+      return Decode<Us...>(type, attr, diagnostic);
+    }
+
+    return diagnostic.Emit(
+        "Wrong attribute type: it doesn't match any of the variant types");
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Automatic dictionary attributes to structs decoding.
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct StructMember {
+  using Type = T;
+
+  explicit StructMember(std::string_view name) : name(name) {}
+  std::string_view name;
+};
+
+namespace internal {
+
+// Decodes dictionary attribute into the object of type `T` that must be
+// constructible from the `Ts` types.
+template <typename T, typename... Ts>
+struct DecodeDictionaryAttr {
+  static constexpr size_t kSize = sizeof...(Ts);
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<T> Decode(const XLA_FFI_Attrs* attrs,
+                                 std::array<std::string_view, kSize> names,
+                                 DiagnosticEngine& diagnostic) {
+    return Decode(attrs, names, std::make_index_sequence<kSize>{}, diagnostic);
+  }
+
+  template <size_t... Is>
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<T> Decode(
+      const XLA_FFI_Attrs* attrs, std::array<std::string_view, kSize> names,
+      std::index_sequence<Is...>, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(kSize != attrs->size)) {
+      return diagnostic.Emit("Wrong number of attributes: expected ")
+             << kSize << " attributes but got " << attrs->size;
+    }
+
+    // TODO(ezhulenev): We rely on dictionary to lookup struct members by name
+    // at run time, however it can become really expensive. We should
+    // pre-compute mapping from `names` to index in the `XLA_FFI_Attrs`
+    // (attributes ordered by name) in a static variable, and rely on it
+    // to decode attributes with constant run time complexity.
+    //
+    // Consider using `static auto decoder = ...` below, and compute mapping in
+    // constructor. Add benchmarks first to know what to improve!
+    internal::DictionaryBase dict(attrs);
+
+    std::tuple<std::optional<Ts>...> members = {
+        dict.get<Ts>(names[Is], diagnostic)...};
+    bool all_decoded = (std::get<Is>(members).has_value() && ...);
+    if (XLA_FFI_PREDICT_FALSE(!all_decoded)) {
+      return std::nullopt;
+    }
+
+    return T{std::move(*std::get<Is>(members))...};
+  }
+};
+
+template <typename... Members>
+auto StructMemberNames(Members... m) {
+  return std::array<std::string_view, sizeof...(Members)>{m.name...};
+}
+
+template <typename T, typename... Members>
+auto DictionaryDecoder(Members... m) {
+  return DecodeDictionaryAttr<T, typename Members::Type...>();
+}
+
+}  // namespace internal
+
+// Example: register decoding for a user-defined struct
+//
+//   struct PairOfI64 { int64_t a; int64_t b; };
+//
+//   XLA_FFI_REGISTER_STRUCT_ATTR_DECODING(
+//     PairOfI64,
+//     StructMember<int64_t>("a"),
+//     StructMember<int64_t>("b"));
+//
+// Automatically registers attributes binding for a struct that allows automatic
+// binding specification inference from a callable signature.
+//
+#define XLA_FFI_REGISTER_STRUCT_ATTR_DECODING(T, ...)                         \
+  namespace xla::ffi {                                                        \
+  template <>                                                                 \
+  struct AttrsBinding<T> {                                                    \
+    using Attrs = T;                                                          \
+  };                                                                          \
+                                                                              \
+  template <>                                                                 \
+  struct AttrDecoding<T> {                                                    \
+    using Type = T;                                                           \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<T> Decode(           \
+        XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {    \
+      if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_DICTIONARY)) {       \
+        diagnostic.Emit("Wrong attribute type: expected ")                    \
+            << XLA_FFI_AttrType_DICTIONARY << " but got " << type;            \
+        return std::nullopt;                                                  \
+      }                                                                       \
+                                                                              \
+      auto decoder = ::xla::ffi::internal::DictionaryDecoder<T>(__VA_ARGS__); \
+      return decltype(decoder)::Decode(                                       \
+          reinterpret_cast<const XLA_FFI_Attrs*>(attr),                       \
+          internal::StructMemberNames(__VA_ARGS__), diagnostic);              \
+    }                                                                         \
+  };                                                                          \
+  } /* namespace xla::ffi */                                                  \
+  static_assert(std::is_class_v<::xla::ffi::AttrsBinding<T>>);                \
+  static_assert(std::is_class_v<::xla::ffi::AttrDecoding<T>>)
+
+// Registers decoding for a user-defined enum class type. Uses enums underlying
+// type to decode the attribute as a scalar value and cast it to the enum type.
+#define XLA_FFI_REGISTER_ENUM_ATTR_DECODING(T)                           \
+  namespace xla::ffi {                                                   \
+  template <>                                                            \
+  struct AttrDecoding<T> {                                               \
+    using Type = T;                                                      \
+    using U = std::underlying_type_t<Type>;                              \
+    static_assert(std::is_enum<Type>::value, "Expected enum class");     \
+                                                                         \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(   \
+        XLA_FFI_AttrType attr_type, void* attr,                          \
+        DiagnosticEngine& diagnostic) {                                  \
+      if (XLA_FFI_PREDICT_FALSE(attr_type != XLA_FFI_AttrType_SCALAR)) { \
+        return diagnostic.Emit("Wrong attribute type: expected ")        \
+               << XLA_FFI_AttrType_SCALAR << " but got " << attr_type;   \
+      }                                                                  \
+                                                                         \
+      auto* scalar = reinterpret_cast<XLA_FFI_Scalar*>(attr);            \
+      constexpr auto expected_dtype =                                    \
+          ::xla::ffi::internal::NativeTypeToCApiDataType<U>();           \
+      if (XLA_FFI_PREDICT_FALSE(scalar->dtype != expected_dtype)) {      \
+        return diagnostic.Emit("Wrong scalar data type: expected ")      \
+               << expected_dtype << " but got " << scalar->dtype;        \
+      }                                                                  \
+                                                                         \
+      auto underlying = *reinterpret_cast<U*>(scalar->value);            \
+      return static_cast<Type>(underlying);                              \
+    }                                                                    \
+  };                                                                     \
+  } /* namespace xla::ffi */                                             \
+  static_assert(std::is_class_v<::xla::ffi::AttrDecoding<T>>)
+
+//===----------------------------------------------------------------------===//
+// Helper macro for registering FFI implementations
+//===----------------------------------------------------------------------===//
+
+// In all macros below we use captureless lambda to function pointer conversion
+// to create a static XLA_FFI_Handler function pointer variable.
+
+// Use explicit binding specification and traits to create a handler.
+#define XLA_FFI_DEFINE_HANDLER_EXPLICIT_WITH_TRAITS(fn, impl, binding, traits) \
+  static constexpr XLA_FFI_Handler* fn = +[](XLA_FFI_CallFrame* call_frame) {  \
+    static auto* handler = binding.To(impl, traits).release();                 \
+    return handler->Call(call_frame);                                          \
+  }
+
+// Use explicit binding specification to create a handler.
+#define XLA_FFI_DEFINE_HANDLER_EXPLICIT(fn, impl, binding)                    \
+  static constexpr XLA_FFI_Handler* fn = +[](XLA_FFI_CallFrame* call_frame) { \
+    static auto* handler = binding.To(impl).release();                        \
+    return handler->Call(call_frame);                                         \
+  }
+
+// Automatically infer binding specification from the implementation.
+#define XLA_FFI_DEFINE_HANDLER_AUTO(fn, impl)                                 \
+  static constexpr XLA_FFI_Handler* fn = +[](XLA_FFI_CallFrame* call_frame) { \
+    static auto* handler = ::xla::ffi::Ffi::BindTo(impl).release();           \
+    return handler->Call(call_frame);                                         \
+  }
+
+#define XLA_FFI_DEFINE_HANDLER_X(x, fn, impl, binding, traits, FUNC, ...) FUNC
+
+// Define XLA FFI handler as a static function pointer variable, which allows
+// to define handlers in nested scopes without polluting the global namespace.
+//
+// This is a trick to define macro with optional parameters.
+// Source: https://stackoverflow.com/a/8814003
+#define XLA_FFI_DEFINE_HANDLER(fn, impl, ...)                               \
+  XLA_FFI_DEFINE_HANDLER_X(                                                 \
+      , fn, impl, ##__VA_ARGS__,                                            \
+      XLA_FFI_DEFINE_HANDLER_EXPLICIT_WITH_TRAITS(fn, impl, ##__VA_ARGS__), \
+      XLA_FFI_DEFINE_HANDLER_EXPLICIT(fn, impl, ##__VA_ARGS__),             \
+      XLA_FFI_DEFINE_HANDLER_AUTO(fn, impl))
+
+// TODO(ezhulenev): Add a callback so that end users can log registration error
+// to appropriate logging destination, e.g. LOG(FATAL) for duplicate internal
+// FFI handlers.
+#define XLA_FFI_REGISTER_HANDLER(API, NAME, PLATFORM, FUNC, ...)    \
+  XLA_FFI_REGISTER_HANDLER_(API, NAME, PLATFORM, FUNC, __COUNTER__, \
+                            ##__VA_ARGS__)
+#define XLA_FFI_REGISTER_HANDLER_(API, NAME, PLATFORM, FUNC, N, ...) \
+  XLA_FFI_REGISTER_HANDLER__(API, NAME, PLATFORM, FUNC, N, ##__VA_ARGS__)
+#define XLA_FFI_REGISTER_HANDLER__(API, NAME, PLATFORM, FUNC, N, ...)       \
+  [[maybe_unused]] static const XLA_FFI_Error*                              \
+      xla_ffi_static_handler_##N##_registered_ = [] {                       \
+        return ::xla::ffi::Ffi::RegisterStaticHandler(API, NAME, PLATFORM,  \
+                                                      FUNC, ##__VA_ARGS__); \
+      }()
+
+// Following two APIs are intended for users who want to export XLA FFI handler
+// from a shared library as a C function symbol.
+
+// Declares C function that returns FFI type id.
+#define XLA_FFI_DECLARE_TYPE_ID_SYMBOL(type_id_fn) \
+  extern "C" XLA_FFI_TypeId* type_id_fn()
+
+// Declares C function that returns FFI type info.
+#define XLA_FFI_DECLARE_TYPE_INFO_SYMBOL(type_info_fn) \
+  extern "C" const XLA_FFI_TypeInfo* type_info_fn()
+
+// Declares C function that implements FFI handler.
+#define XLA_FFI_DECLARE_HANDLER_SYMBOL(fn) \
+  extern "C" XLA_FFI_Error* fn(XLA_FFI_CallFrame* call_frame)
+
+// Defines C function that implements FFI handler.
+#define XLA_FFI_DEFINE_HANDLER_SYMBOL(fn, impl, ...)                           \
+  extern "C" XLA_FFI_Error* fn(XLA_FFI_CallFrame* call_frame) {                \
+    XLA_FFI_DEFINE_HANDLER(handler, impl, ##__VA_ARGS__);                      \
+    return (*handler)(call_frame);                                             \
+  }                                                                            \
+                                                                               \
+  static_assert(                                                               \
+      std::is_invocable_r_v<XLA_FFI_Error*, decltype(fn), XLA_FFI_CallFrame*>, \
+      "FFI handler must return XLA_FFI_Error* and accept XLA_FFI_CallFrame*")
+
+}  // namespace xla::ffi
+
+#endif  // XLA_FFI_API_API_H_

--- a/extern/xla/xla/ffi/api/c_api.h
+++ b/extern/xla/xla/ffi/api/c_api.h
@@ -1,0 +1,788 @@
+/* Copyright 2023 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_FFI_API_C_API_H_
+#define XLA_FFI_API_C_API_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+// XLA FFI C API follows PJRT API style for consistency. See `pjrt_c_api.h`.
+// More details on versioning strategy and example version checks:
+// https://github.com/tensorflow/community/blob/master/rfcs/20200612-stream-executor-c-api/C_API_versioning_strategy.md
+
+// Every struct passed across the C API boundary has its size as a member, and
+// we use it as a sanity check for API compatibility.
+#define XLA_FFI_STRUCT_SIZE(struct_type, last_field) \
+  (offsetof(struct_type, last_field) + sizeof(((struct_type*)0)->last_field))
+
+// Must update XLA_FFI_DEFINE_STRUCT_TRAITS with the new `last_field` after
+// adding a new member to a struct.
+#define XLA_FFI_DEFINE_STRUCT_TRAITS(sname, last_field) \
+  typedef struct sname sname;                           \
+  enum { sname##_STRUCT_SIZE = XLA_FFI_STRUCT_SIZE(sname, last_field) }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct XLA_FFI_Api XLA_FFI_Api;                  // Forward declare
+typedef struct XLA_FFI_InternalApi XLA_FFI_InternalApi;  // Forward declare
+
+//===----------------------------------------------------------------------===//
+// Extensions
+//===----------------------------------------------------------------------===//
+
+typedef enum {
+  XLA_FFI_Extension_Metadata = 1,
+} XLA_FFI_Extension_Type;
+
+typedef struct XLA_FFI_Extension_Base {
+  size_t struct_size;
+  XLA_FFI_Extension_Type type;
+  struct XLA_FFI_Extension_Base* next;
+} XLA_FFI_Extension_Base;
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Extension_Base, next);
+
+//===----------------------------------------------------------------------===//
+// Version
+//===----------------------------------------------------------------------===//
+
+// XLA FFI provides a stable binary API for registering custom calls with
+// XLA runtime. XLA runtime guarantees that old API version are supported for
+// at least 12 months, after that point FFI library has to be recompiled with
+// latest XLA FFI headers to support new features. We don't plan to break ABI
+// compatibility, unless it's absolutely necessary to enable new features that
+// can't be implemented in a backward compatible way.
+//
+// The range of supported API versions is defined in `xla/ffi/ffi_api.cc`.
+
+// Incremented when an ABI-incompatible change is made to the interface.
+//
+// Major changes include:
+// * Deleting a method or argument
+// * Changing the type of an argument
+// * Rearranging fields in the XLA_FFI_Api or argument structs
+#define XLA_FFI_API_MAJOR 0
+
+// Incremented when the interface is updated in a way that is potentially
+// ABI-compatible with older versions, if supported by the caller and/or
+// implementation.
+//
+// Callers can implement forwards compatibility by using XLA_FFI_Api_Version to
+// check if the implementation is aware of newer interface additions.
+//
+// Implementations can implement backwards compatibility by using the
+// `struct_size` fields to detect how many struct fields the caller is aware of.
+//
+// Minor changes include:
+// * Adding a new field to the XLA_FFI_Api or argument structs
+// * Renaming a method or argument (doesn't affect ABI)
+#define XLA_FFI_API_MINOR 3
+
+struct XLA_FFI_Api_Version {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  int major_version;  // out
+  int minor_version;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Api_Version, minor_version);
+
+//===----------------------------------------------------------------------===//
+// Error codes
+//===----------------------------------------------------------------------===//
+
+// XLA FFI error is a mechanism to communicate errors between XLA and XLA FFI
+// via a set of C APIs. This is somewhat similar to type-erased version of
+// absl::Status exposed via API with opaque pointers.
+//
+// Returning NULL error is equivalent to returning absl::OkStatus().
+//
+// Ownership of an XLA_FFI_Error is always transferred to the caller, and the
+// caller is responsible for destroying it:
+//
+// (1) If the error is returned from an XLA FFI handler, the XLA runtime will
+//     destroy it (XLA is the caller who calls into the handler implementation).
+//
+// (2) If the error is returned from an XLA FFI API call, the caller is
+//     responsible for destroying it.
+typedef struct XLA_FFI_Error XLA_FFI_Error;
+
+// Codes are based on https://abseil.io/docs/cpp/guides/status-codes
+typedef enum {
+  XLA_FFI_Error_Code_OK = 0,
+  XLA_FFI_Error_Code_CANCELLED = 1,
+  XLA_FFI_Error_Code_UNKNOWN = 2,
+  XLA_FFI_Error_Code_INVALID_ARGUMENT = 3,
+  XLA_FFI_Error_Code_DEADLINE_EXCEEDED = 4,
+  XLA_FFI_Error_Code_NOT_FOUND = 5,
+  XLA_FFI_Error_Code_ALREADY_EXISTS = 6,
+  XLA_FFI_Error_Code_PERMISSION_DENIED = 7,
+  XLA_FFI_Error_Code_RESOURCE_EXHAUSTED = 8,
+  XLA_FFI_Error_Code_FAILED_PRECONDITION = 9,
+  XLA_FFI_Error_Code_ABORTED = 10,
+  XLA_FFI_Error_Code_OUT_OF_RANGE = 11,
+  XLA_FFI_Error_Code_UNIMPLEMENTED = 12,
+  XLA_FFI_Error_Code_INTERNAL = 13,
+  XLA_FFI_Error_Code_UNAVAILABLE = 14,
+  XLA_FFI_Error_Code_DATA_LOSS = 15,
+  XLA_FFI_Error_Code_UNAUTHENTICATED = 16
+} XLA_FFI_Error_Code;
+
+//===----------------------------------------------------------------------===//
+// Error reporting APIs
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_Error_Create_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  const char* message;
+  XLA_FFI_Error_Code errc;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_Create_Args, errc);
+
+typedef XLA_FFI_Error* XLA_FFI_Error_Create(XLA_FFI_Error_Create_Args* args);
+
+struct XLA_FFI_Error_GetMessage_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Error* error;
+  const char* message;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_GetMessage_Args, message);
+
+typedef void XLA_FFI_Error_GetMessage(XLA_FFI_Error_GetMessage_Args* args);
+
+struct XLA_FFI_Error_Destroy_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Error* error;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Error_Destroy_Args, error);
+
+typedef void XLA_FFI_Error_Destroy(XLA_FFI_Error_Destroy_Args* args);
+
+//===----------------------------------------------------------------------===//
+// DataType
+//===----------------------------------------------------------------------===//
+
+// This enum corresponds to xla::PrimitiveType enum defined in `xla_data.proto`.
+// LINT.IfChange
+typedef enum {
+  XLA_FFI_DataType_INVALID = 0,
+  XLA_FFI_DataType_PRED = 1,
+  XLA_FFI_DataType_S1 = 30,
+  XLA_FFI_DataType_S2 = 26,
+  XLA_FFI_DataType_S4 = 21,
+  XLA_FFI_DataType_S8 = 2,
+  XLA_FFI_DataType_S16 = 3,
+  XLA_FFI_DataType_S32 = 4,
+  XLA_FFI_DataType_S64 = 5,
+  XLA_FFI_DataType_U1 = 31,
+  XLA_FFI_DataType_U2 = 27,
+  XLA_FFI_DataType_U4 = 22,
+  XLA_FFI_DataType_U8 = 6,
+  XLA_FFI_DataType_U16 = 7,
+  XLA_FFI_DataType_U32 = 8,
+  XLA_FFI_DataType_U64 = 9,
+  XLA_FFI_DataType_F16 = 10,
+  XLA_FFI_DataType_F32 = 11,
+  XLA_FFI_DataType_F64 = 12,
+  XLA_FFI_DataType_BF16 = 16,
+  XLA_FFI_DataType_C64 = 15,
+  XLA_FFI_DataType_C128 = 18,
+  XLA_FFI_DataType_TOKEN = 17,
+  XLA_FFI_DataType_F8E5M2 = 19,
+  XLA_FFI_DataType_F8E3M4 = 29,
+  XLA_FFI_DataType_F8E4M3 = 28,
+  XLA_FFI_DataType_F8E4M3FN = 20,
+  XLA_FFI_DataType_F8E4M3B11FNUZ = 23,
+  XLA_FFI_DataType_F8E5M2FNUZ = 24,
+  XLA_FFI_DataType_F8E4M3FNUZ = 25,
+  XLA_FFI_DataType_F4E2M1FN = 32,
+  XLA_FFI_DataType_F8E8M0FNU = 33,
+} XLA_FFI_DataType;
+// LINT.ThenChange(ffi_test.cc)
+
+//===----------------------------------------------------------------------===//
+// Builtin argument types
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_Buffer {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_DataType dtype;
+  void* data;
+  int64_t rank;
+  int64_t* dims;  // length == rank
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Buffer, dims);
+
+typedef enum {
+  XLA_FFI_ArgType_BUFFER = 1,
+} XLA_FFI_ArgType;
+
+//===----------------------------------------------------------------------===//
+// Builtin result types
+//===----------------------------------------------------------------------===//
+
+typedef enum {
+  XLA_FFI_RetType_BUFFER = 1,
+} XLA_FFI_RetType;
+
+//===----------------------------------------------------------------------===//
+// Builtin attribute types
+//===----------------------------------------------------------------------===//
+
+typedef enum {
+  XLA_FFI_AttrType_ARRAY = 1,
+  XLA_FFI_AttrType_DICTIONARY = 2,
+  XLA_FFI_AttrType_SCALAR = 3,
+  XLA_FFI_AttrType_STRING = 4,
+} XLA_FFI_AttrType;
+
+//===----------------------------------------------------------------------===//
+// Execution context
+//===----------------------------------------------------------------------===//
+
+// Execution context provides access to per-invocation state.
+typedef struct XLA_FFI_ExecutionContext XLA_FFI_ExecutionContext;
+
+//===----------------------------------------------------------------------===//
+// Primitives
+//===----------------------------------------------------------------------===//
+
+// We use byte spans to pass strings to handlers because strings might not be
+// null terminated, and even if they are, looking for a null terminator can
+// become very expensive in tight loops.
+typedef struct XLA_FFI_ByteSpan {
+  const char* ptr;
+  size_t len;
+} XLA_FFI_ByteSpan;
+
+// A struct to pass a scalar value to FFI handler.
+typedef struct XLA_FFI_Scalar {
+  XLA_FFI_DataType dtype;
+  void* value;
+} XLA_FFI_Scalar;
+
+// A struct to pass a dense array to FFI handler.
+typedef struct XLA_FFI_Array {
+  XLA_FFI_DataType dtype;
+  size_t size;
+  void* data;
+} XLA_FFI_Array;
+
+//===----------------------------------------------------------------------===//
+// Type registry
+//===----------------------------------------------------------------------===//
+
+// TypeId uniquely identifies a user-defined type in a given XLA FFI instance.
+typedef struct XLA_FFI_TypeId {
+  int64_t type_id;
+} XLA_FFI_TypeId;
+
+// TypeInfo contains function pointers required by XLA runtime to manipulate
+// user-defined types. For example stateful handlers must tell XLA runtime how
+// to destroy their state when executable is being destroyed.
+typedef struct XLA_FFI_TypeInfo {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  void (*deleter)(void* object);
+} XLA_FFI_TypeInfo;
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_TypeInfo, deleter);
+
+//===----------------------------------------------------------------------===//
+// Future
+//===----------------------------------------------------------------------===//
+
+// XLA FFI future is a mechanism to signal a result of asynchronous computation
+// (FFI handler) to the XLA runtime. It is similar to `std::future<void>` in C++
+// standard library, and implemented on top of `tsl::AsyncValue` in XLA runtime.
+//
+// XLA FFI users should use `Future` and `Promise` types defined in `xla::ffi`
+// namespace (see `ffi/api/ffi.h`), instead of using this API directly.
+typedef struct XLA_FFI_Future XLA_FFI_Future;
+
+struct XLA_FFI_Future_Create_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Future* future;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Future_Create_Args, extension_start);
+
+typedef XLA_FFI_Error* XLA_FFI_Future_Create(XLA_FFI_Future_Create_Args* args);
+
+struct XLA_FFI_Future_SetAvailable_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Future* future;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Future_SetAvailable_Args, future);
+
+typedef XLA_FFI_Error* XLA_FFI_Future_SetAvailable(
+    XLA_FFI_Future_SetAvailable_Args* args);
+
+struct XLA_FFI_Future_SetError_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+  XLA_FFI_Future* future;
+  XLA_FFI_Error* error;  // ownership is transferred to the XLA runtime
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Future_SetError_Args, error);
+
+typedef XLA_FFI_Error* XLA_FFI_Future_SetError(
+    XLA_FFI_Future_SetError_Args* args);
+
+//===----------------------------------------------------------------------===//
+// Call frame
+//===----------------------------------------------------------------------===//
+
+// XLA runtime has multiple execution stages and it is possible to run
+// different handlers for each stage:
+//
+// (1) Instantiate - called when FFI handler is instantiated as a part of XLA
+//     executable instantiation. Every call site will have its own "instance" of
+//     the FFI handler, and it is possible to attach an arbitrary user-defined
+//     state to the FFI handler instance, and get it back in other execution
+//     stages. Constructed state owned by the XLA runtime and destructed
+//     together with a parent executable.
+//
+// (2) Prepare - called before the execution to let FFI handlers to prepare
+//     for the execution and request resources from runtime, i.e. in XLA:GPU
+//     we use prepare stage to request collective cliques.
+//
+// (3) Initialize - called before the execution after acquiring all the
+//     resources requested in the prepare stage.
+//
+// (4) Execute - called when FFI handler is executed. Note that FFI handler
+//     can be called as a part of command buffer capture (CUDA graph capture
+//     on GPU backend) and argument buffers might contain uninitialized
+//     values in this case.
+//
+// XLA program (HLO module) compiled to an XLA executable that can be executed
+// on any device accessible to the process, and by extension FFI handlers are
+// not instantiated for any particular device, but for a process. FFI handlers
+// running at instantiation stage do not have access to the underlying device
+// (memory allocation, stream, etc.) and arguments, however they can access
+// execution context and attributes.
+//
+// It is undefined behavior to access argument buffers in prepare and initialize
+// stages as they might not be initialized yet. However it is safe to use memory
+// address as it is assigned ahead of time by buffer assignment.
+typedef enum {
+  XLA_FFI_ExecutionStage_INSTANTIATE = 0,
+  XLA_FFI_ExecutionStage_PREPARE = 1,
+  XLA_FFI_ExecutionStage_INITIALIZE = 2,
+  XLA_FFI_ExecutionStage_EXECUTE = 3,
+} XLA_FFI_ExecutionStage;
+
+struct XLA_FFI_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  int64_t size;
+  XLA_FFI_ArgType* types;  // length == size
+  void** args;             // length == size
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Args, args);
+
+struct XLA_FFI_Rets {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  int64_t size;
+  XLA_FFI_RetType* types;  // length == size
+  void** rets;             // length == size
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Rets, rets);
+
+// FFI handler attributes are always sorted by name, so that the handler can
+// rely on binary search to look up attributes by name.
+struct XLA_FFI_Attrs {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  int64_t size;
+  XLA_FFI_AttrType* types;   // length == size
+  XLA_FFI_ByteSpan** names;  // length == size
+  void** attrs;              // length == size
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Attrs, attrs);
+
+struct XLA_FFI_CallFrame {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  const XLA_FFI_Api* api;
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_ExecutionStage stage;
+  XLA_FFI_Args args;
+  XLA_FFI_Rets rets;
+  XLA_FFI_Attrs attrs;
+
+  // XLA FFI handler implementation can use `future` to signal a result of
+  // asynchronous computation to the XLA runtime. XLA runtime will keep all
+  // arguments, results and attributes alive until `future` is completed.
+  XLA_FFI_Future* future;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_CallFrame, attrs);
+
+//===----------------------------------------------------------------------===//
+// FFI handler
+//===----------------------------------------------------------------------===//
+
+// External functions registered with XLA as FFI handlers.
+typedef XLA_FFI_Error* XLA_FFI_Handler(XLA_FFI_CallFrame* call_frame);
+
+// XLA FFI handlers for execution stages (see XLA_FFI_ExecutionStage).
+typedef struct XLA_FFI_Handler_Bundle {
+  XLA_FFI_Handler* instantiate;  // optional
+  XLA_FFI_Handler* prepare;      // optional
+  XLA_FFI_Handler* initialize;   // optional
+  XLA_FFI_Handler* execute;      // required
+} XLA_FFI_Handler_Bundle;
+
+enum XLA_FFI_Handler_TraitsBits {
+  // Calls to FFI handler are safe to trace into the command buffer. It means
+  // that calls to FFI handler always launch exactly the same device operations
+  // (can depend on attribute values) that can be captured and then replayed.
+  XLA_FFI_HANDLER_TRAITS_COMMAND_BUFFER_COMPATIBLE = 1u << 0,
+};
+
+typedef uint32_t XLA_FFI_Handler_Traits;
+
+struct XLA_FFI_Handler_Register_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ByteSpan name;
+  XLA_FFI_ByteSpan platform;
+  XLA_FFI_Handler_Bundle bundle;
+  XLA_FFI_Handler_Traits traits;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Handler_Register_Args, traits);
+
+typedef XLA_FFI_Error* XLA_FFI_Handler_Register(
+    XLA_FFI_Handler_Register_Args* args);
+
+//===----------------------------------------------------------------------===//
+// TypeId
+//===----------------------------------------------------------------------===//
+
+#define XLA_FFI_UNKNOWN_TYPE_ID XLA_FFI_TypeId{0}
+
+struct XLA_FFI_Type_Register_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ByteSpan name;
+  XLA_FFI_TypeId* type_id;  // in-out
+  const XLA_FFI_TypeInfo* type_info;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Type_Register_Args, type_id);
+
+// Registers user type `name` with XLA. If type id is `XLA_FFI_UNKNOWN_TYPE_ID`,
+// XLA will assign a unique type id and return it in `type_id` out argument,
+// otherwise XLA will verify that type id is unique and matches the type id of
+// the type registered with the same `name` earlier.
+typedef XLA_FFI_Error* XLA_FFI_Type_Register(XLA_FFI_Type_Register_Args* args);
+
+//===----------------------------------------------------------------------===//
+// ExecutionContext
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_ExecutionContext_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_TypeId* type_id;
+  void* data;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_ExecutionContext_Get_Args, data);
+
+// Returns an opaque data from the execution context for a given type id.
+typedef XLA_FFI_Error* XLA_FFI_ExecutionContext_Get(
+    XLA_FFI_ExecutionContext_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// State
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_State_Set_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_ExecutionStage stage;
+  XLA_FFI_TypeId* type_id;
+  void* state;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_State_Set_Args, state);
+
+// Sets execution state to the `state` of type `type_id`. Returns an error if
+// state already set.
+typedef XLA_FFI_Error* XLA_FFI_State_Set(XLA_FFI_State_Set_Args* args);
+
+struct XLA_FFI_State_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_ExecutionStage stage;
+  XLA_FFI_TypeId* type_id;
+  void* state;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_State_Get_Args, state);
+
+// Gets execution state of type `type_id`. Returns an error if state is not set,
+// or set with a state of a different type.
+typedef XLA_FFI_Error* XLA_FFI_State_Get(XLA_FFI_State_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// Stream
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_Stream_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  void* stream;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Stream_Get_Args, stream);
+
+// Returns an underling platform-specific stream via out argument, i.e. for CUDA
+// platform it returns `CUstream` (same as `cudaStream`).
+typedef XLA_FFI_Error* XLA_FFI_Stream_Get(XLA_FFI_Stream_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// Device memory allocation
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_DeviceMemory_Allocate_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  size_t size;
+  size_t alignment;
+  void* data;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_DeviceMemory_Allocate_Args, data);
+
+// Allocates a block of memory on the device bound to the execution context.
+typedef XLA_FFI_Error* XLA_FFI_DeviceMemory_Allocate(
+    XLA_FFI_DeviceMemory_Allocate_Args* args);
+
+struct XLA_FFI_DeviceMemory_Free_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  size_t size;
+  void* data;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_DeviceMemory_Free_Args, data);
+
+// Frees previously allocated device memory.
+typedef XLA_FFI_Error* XLA_FFI_DeviceMemory_Free(
+    XLA_FFI_DeviceMemory_Free_Args* args);
+
+//===----------------------------------------------------------------------===//
+// ThreadPool
+//===----------------------------------------------------------------------===//
+
+// A function pointer for a task to be scheduled on a thread pool. XLA runtime
+// will call this function with a user-defined `data` pointer on one of the
+// runtime-managed threads. For XLA:CPU backends the task will be invoked on
+// a thread pool that runs all compute tasks (Eigen thread pool).
+//
+// IMPORTANT: Users must not rely on any particular execution order or the
+// number of available threads. Tasks can be executed in the caller thread, or
+// in a thread pool with size `1`, and it is unsafe to assume that all scheduled
+// tasks can be executed in parallel.
+typedef void XLA_FFI_Task(void* data);
+
+struct XLA_FFI_ThreadPool_Schedule_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  XLA_FFI_Task* task;
+  void* data;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_ThreadPool_Schedule_Args, data);
+
+// Schedules a task to be executed on a thread pool managed by XLA runtime.
+// Returns an error if thread pool is not available.
+typedef XLA_FFI_Error* XLA_FFI_ThreadPool_Schedule(
+    XLA_FFI_ThreadPool_Schedule_Args* args);
+
+struct XLA_FFI_ThreadPool_NumThreads_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  int64_t* num_threads;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_ThreadPool_NumThreads_Args, num_threads);
+
+// Returns the number of threads in the thread pool managed by XLA runtime.
+typedef XLA_FFI_Error* XLA_FFI_ThreadPool_NumThreads(
+    XLA_FFI_ThreadPool_NumThreads_Args* args);
+
+//===----------------------------------------------------------------------===//
+// RunId
+//===----------------------------------------------------------------------===//
+
+// RunId is a unique identifier for a particular "logical execution" of an XLA
+// model.
+//
+// A logical execution might encompass multiple executions of one or more
+// HloModules. Runs that are part of the same logical execution can communicate
+// via collective ops, whereas runs that are part of different logical
+// executions are isolated.
+//
+// Corresponds to `::xla::RunId` (see `xla/executable_run_options.h`).
+
+struct XLA_FFI_RunId_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  int64_t run_id;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_RunId_Get_Args, run_id);
+
+// Returns a unique identifier for the current logical execution.
+typedef XLA_FFI_Error* XLA_FFI_RunId_Get(XLA_FFI_RunId_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// DeviceOrdinal
+//===----------------------------------------------------------------------===//
+
+struct XLA_FFI_DeviceOrdinal_Get_Args {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_ExecutionContext* ctx;
+  int32_t device_ordinal;  // out
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_DeviceOrdinal_Get_Args, device_ordinal);
+
+// Returns a unique identifier for the current logical execution.
+typedef XLA_FFI_Error* XLA_FFI_DeviceOrdinal_Get(
+    XLA_FFI_DeviceOrdinal_Get_Args* args);
+
+//===----------------------------------------------------------------------===//
+// Metadata extension
+//===----------------------------------------------------------------------===//
+
+// XLA FFI handler metadata allows the XLA runtime to query handler properties
+// during XLA compilation and execution. We use a metadata extension to verify
+// that XLA is compatible with the FFI version used to compile the handler.
+struct XLA_FFI_Metadata {
+  size_t struct_size;
+
+  XLA_FFI_Api_Version api_version;
+  XLA_FFI_Handler_Traits traits;
+
+  // For stateful handlers, the type id of the state type. Otherwise, the type
+  // id is `XLA_FFI_UNKNOWN_TYPE_ID`.
+  XLA_FFI_TypeId state_type_id;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Metadata, traits);
+
+struct XLA_FFI_Metadata_Extension {
+  XLA_FFI_Extension_Base extension_base;
+  XLA_FFI_Metadata* metadata;
+};
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Metadata_Extension, metadata);
+
+//===----------------------------------------------------------------------===//
+// API access
+//===----------------------------------------------------------------------===//
+
+#define _XLA_FFI_API_STRUCT_FIELD(fn_type) fn_type* fn_type
+
+struct XLA_FFI_Api {
+  size_t struct_size;
+  XLA_FFI_Extension_Base* extension_start;
+
+  XLA_FFI_Api_Version api_version;
+  const XLA_FFI_InternalApi* internal_api;
+
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_Create);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_GetMessage);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Error_Destroy);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Handler_Register);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Stream_Get);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Type_Register);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_ExecutionContext_Get);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_State_Set);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_State_Get);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_DeviceMemory_Allocate);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_DeviceMemory_Free);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_ThreadPool_Schedule);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_ThreadPool_NumThreads);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_Create);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_SetAvailable);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_Future_SetError);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_RunId_Get);
+  _XLA_FFI_API_STRUCT_FIELD(XLA_FFI_DeviceOrdinal_Get);
+};
+
+#undef _XLA_FFI_API_STRUCT_FIELD
+
+XLA_FFI_DEFINE_STRUCT_TRAITS(XLA_FFI_Api, XLA_FFI_DeviceOrdinal_Get);
+
+const XLA_FFI_Api* XLA_FFI_GetApi();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // XLA_FFI_API_C_API_H_

--- a/extern/xla/xla/ffi/api/ffi.h
+++ b/extern/xla/xla/ffi/api/ffi.h
@@ -1,0 +1,1705 @@
+/* Copyright 2023 The OpenXLA Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef XLA_FFI_API_FFI_H_
+#define XLA_FFI_API_FFI_H_
+
+#ifdef XLA_FFI_FFI_H_
+#error Two different XLA FFI implementations cannot be included together. \
+       See README.md for more details.
+#endif  // XLA_FFI_FFI_H_
+
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <complex>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <mutex>  // NOLINT
+#include <numeric>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "xla/ffi/api/c_api.h"
+
+// IWYU pragma: begin_exports
+#include "xla/ffi/api/api.h"
+// IWYU pragma: end_exports
+
+namespace xla::ffi {
+
+//===----------------------------------------------------------------------===//
+// XLA FFI Api
+//===----------------------------------------------------------------------===//
+
+// This is a declaration of the API that returns an XLA:FFI instance for a
+// process. This API is implemented in `xla/ffi/ffi_api.cc` and implementation
+// must be linked into the target process exactly once, or it is possible to
+// have multiple global static registries of FFI handlers and types.
+const XLA_FFI_Api* GetXlaFfiApi();
+
+//===----------------------------------------------------------------------===//
+// Type aliases for XLA_FFI C structs.
+//===----------------------------------------------------------------------===//
+
+// All user data types that are passed via the execution context or state must
+// be registered with the XLA FFI ahead of time to get unique type id.
+using TypeId = XLA_FFI_TypeId;      // NOLINT
+using TypeInfo = XLA_FFI_TypeInfo;  // NOLINT
+
+enum class DataType : uint8_t {
+  INVALID = XLA_FFI_DataType_INVALID,
+  PRED = XLA_FFI_DataType_PRED,
+  S1 = XLA_FFI_DataType_S1,
+  S2 = XLA_FFI_DataType_S2,
+  S4 = XLA_FFI_DataType_S4,
+  S8 = XLA_FFI_DataType_S8,
+  S16 = XLA_FFI_DataType_S16,
+  S32 = XLA_FFI_DataType_S32,
+  S64 = XLA_FFI_DataType_S64,
+  U1 = XLA_FFI_DataType_U1,
+  U2 = XLA_FFI_DataType_U2,
+  U4 = XLA_FFI_DataType_U4,
+  U8 = XLA_FFI_DataType_U8,
+  U16 = XLA_FFI_DataType_U16,
+  U32 = XLA_FFI_DataType_U32,
+  U64 = XLA_FFI_DataType_U64,
+  F16 = XLA_FFI_DataType_F16,
+  F32 = XLA_FFI_DataType_F32,
+  F64 = XLA_FFI_DataType_F64,
+  BF16 = XLA_FFI_DataType_BF16,
+  C64 = XLA_FFI_DataType_C64,
+  C128 = XLA_FFI_DataType_C128,
+  TOKEN = XLA_FFI_DataType_TOKEN,
+  F8E5M2 = XLA_FFI_DataType_F8E5M2,
+  F8E4M3 = XLA_FFI_DataType_F8E4M3,
+  F8E4M3FN = XLA_FFI_DataType_F8E4M3FN,
+  F8E4M3B11FNUZ = XLA_FFI_DataType_F8E4M3B11FNUZ,
+  F8E5M2FNUZ = XLA_FFI_DataType_F8E5M2FNUZ,
+  F8E4M3FNUZ = XLA_FFI_DataType_F8E4M3FNUZ,
+  F8E3M4 = XLA_FFI_DataType_F8E3M4,
+  F4E2M1FN = XLA_FFI_DataType_F4E2M1FN,
+  F8E8M0FNU = XLA_FFI_DataType_F8E8M0FNU,
+};
+
+// Create aliases in ::xla::ffi namespace for all DataTypes, for consistency
+// with xla that defines PrimitiveType enums in ::xla namespace.
+inline constexpr DataType PRED = DataType::PRED;
+inline constexpr DataType S1 = DataType::S1;
+inline constexpr DataType S2 = DataType::S2;
+inline constexpr DataType S4 = DataType::S4;
+inline constexpr DataType S8 = DataType::S8;
+inline constexpr DataType S16 = DataType::S16;
+inline constexpr DataType S32 = DataType::S32;
+inline constexpr DataType S64 = DataType::S64;
+inline constexpr DataType U1 = DataType::U1;
+inline constexpr DataType U2 = DataType::U2;
+inline constexpr DataType U4 = DataType::U4;
+inline constexpr DataType U8 = DataType::U8;
+inline constexpr DataType U16 = DataType::U16;
+inline constexpr DataType U32 = DataType::U32;
+inline constexpr DataType U64 = DataType::U64;
+inline constexpr DataType F16 = DataType::F16;
+inline constexpr DataType F32 = DataType::F32;
+inline constexpr DataType F64 = DataType::F64;
+inline constexpr DataType BF16 = DataType::BF16;
+inline constexpr DataType C64 = DataType::C64;
+inline constexpr DataType C128 = DataType::C128;
+inline constexpr DataType TOKEN = DataType::TOKEN;
+inline constexpr DataType F8E5M2 = DataType::F8E5M2;
+inline constexpr DataType F8E4M3 = DataType::F8E4M3;
+inline constexpr DataType F8E4M3FN = DataType::F8E4M3FN;
+inline constexpr DataType F8E4M3B11FNUZ = DataType::F8E4M3B11FNUZ;
+inline constexpr DataType F8E5M2FNUZ = DataType::F8E5M2FNUZ;
+inline constexpr DataType F8E4M3FNUZ = DataType::F8E4M3FNUZ;
+inline constexpr DataType F8E3M4 = DataType::F8E3M4;
+inline constexpr DataType F4E2M1FN = DataType::F4E2M1FN;
+inline constexpr DataType F8E8M0FNU = DataType::F8E8M0FNU;
+
+inline std::ostream& operator<<(std::ostream& os, const DataType dtype) {
+  return os << static_cast<XLA_FFI_DataType>(dtype);
+}
+
+constexpr size_t ByteWidth(DataType dtype) {
+  switch (dtype) {
+    case DataType::INVALID:
+    case DataType::TOKEN:
+      return 0;
+    case DataType::PRED:
+      return 1;
+    case DataType::S1:
+    case DataType::S2:
+    case DataType::S4:
+    case DataType::S8:
+    case DataType::U1:
+    case DataType::U2:
+    case DataType::U4:
+    case DataType::U8:
+    case DataType::F8E5M2:
+    case DataType::F8E4M3:
+    case DataType::F8E4M3FN:
+    case DataType::F8E4M3B11FNUZ:
+    case DataType::F8E5M2FNUZ:
+    case DataType::F8E4M3FNUZ:
+    case DataType::F8E3M4:
+    case DataType::F4E2M1FN:
+    case DataType::F8E8M0FNU:
+      return 1;
+    case DataType::S16:
+    case DataType::U16:
+    case DataType::F16:
+    case DataType::BF16:
+      return 2;
+    case DataType::S32:
+    case DataType::U32:
+    case DataType::F32:
+      return 4;
+    case DataType::S64:
+    case DataType::U64:
+    case DataType::F64:
+      return 8;
+    case DataType::C64:
+      return 8;
+    case DataType::C128:
+      return 16;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Span is non-owning view into contiguous values of type `T`.
+//===----------------------------------------------------------------------===//
+
+// TODO(ezhulenev): Replace with `std::span` when C++20 is available.
+template <typename T>
+class Span {
+ public:
+  constexpr Span() : data_(nullptr), size_(0) {}
+
+  Span(T* data, size_t size) : data_(data), size_(size) {}
+  Span(const std::vector<std::remove_const_t<T>>& vec)  // NOLINT
+      : Span(vec.data(), vec.size()) {}
+
+  T& operator[](size_t index) const { return data_[index]; }
+
+  bool operator==(const Span<T>& other) const {
+    return size() == other.size() && std::equal(begin(), end(), other.begin());
+  }
+
+  T& front() const { return data_[0]; }
+  T& back() const { return data_[size_ - 1]; }
+  Span<T> first(size_t n) const { return Span<T>(data_, n); }
+  Span<T> last(size_t n) const { return Span<T>(data_ + size_ - n, n); }
+  size_t size() const { return size_; }
+
+  T* begin() const { return data_; }
+  T* end() const { return data_ + size_; }
+
+ private:
+  T* data_;
+  size_t size_;
+};
+
+//===----------------------------------------------------------------------===//
+// Error
+//===----------------------------------------------------------------------===//
+
+enum class ErrorCode : uint8_t {
+  kOk = XLA_FFI_Error_Code_OK,
+  kCancelled = XLA_FFI_Error_Code_CANCELLED,
+  kUnknown = XLA_FFI_Error_Code_UNKNOWN,
+  kInvalidArgument = XLA_FFI_Error_Code_INVALID_ARGUMENT,
+  kDeadlineExceeded = XLA_FFI_Error_Code_DEADLINE_EXCEEDED,
+  kNotFound = XLA_FFI_Error_Code_NOT_FOUND,
+  kAlreadyExists = XLA_FFI_Error_Code_ALREADY_EXISTS,
+  kPermissionDenied = XLA_FFI_Error_Code_PERMISSION_DENIED,
+  kResourceExhausted = XLA_FFI_Error_Code_RESOURCE_EXHAUSTED,
+  kFailedPrecondition = XLA_FFI_Error_Code_FAILED_PRECONDITION,
+  kAborted = XLA_FFI_Error_Code_ABORTED,
+  kOutOfRange = XLA_FFI_Error_Code_OUT_OF_RANGE,
+  kUnimplemented = XLA_FFI_Error_Code_UNIMPLEMENTED,
+  kInternal = XLA_FFI_Error_Code_INTERNAL,
+  kUnavailable = XLA_FFI_Error_Code_UNAVAILABLE,
+  kDataLoss = XLA_FFI_Error_Code_DATA_LOSS,
+  kUnauthenticated = XLA_FFI_Error_Code_UNAUTHENTICATED,
+};
+
+class Error {
+ public:
+  Error() = default;
+
+  Error(ErrorCode errc, std::string message)
+      : errc_(errc), message_(std::move(message)) {}
+
+  Error(XLA_FFI_Error_Code errc, std::string message)
+      : Error(static_cast<ErrorCode>(errc), std::move(message)) {}
+
+  bool success() const { return errc_ == ErrorCode::kOk; }
+  bool failure() const { return !success(); }
+
+  std::optional<ErrorCode> errc() const { return errc_; }
+  const std::string& message() const { return message_; }
+
+  static Error Success() { return Error(); }
+
+  static Error Internal(std::string message) {
+    return Error(ErrorCode::kInternal, std::move(message));
+  }
+
+  static Error InvalidArgument(std::string message) {
+    return Error(ErrorCode::kInvalidArgument, std::move(message));
+  }
+
+ private:
+  ErrorCode errc_ = ErrorCode::kOk;
+  std::string message_;
+};
+
+//===----------------------------------------------------------------------===//
+// Expected<T, E> and ErrorOr<T>
+//===----------------------------------------------------------------------===//
+
+// Forward declare.
+template <typename E>
+class Unexpected;
+
+// TODO(slebedev): Replace with `std::expected` when C++23 is available.
+template <typename T, typename E>
+class Expected {
+ public:
+  constexpr Expected(T value) : data_(std::move(value)) {}  // NOLINT
+  constexpr Expected(Unexpected<E> u);                      // NOLINT
+
+  constexpr operator bool() const {  // NOLINT
+    return has_value();
+  }
+
+  constexpr T& operator*() & { return value(); }
+  constexpr const T& operator*() const& { return value(); }
+  constexpr T&& operator*() && { return std::move(value()); }
+  constexpr const T& operator*() const&& { return std::move(value()); }
+
+  constexpr T* operator->() { return &value(); }
+  constexpr const T* operator->() const { return &value(); }
+
+  constexpr bool has_value() const { return std::holds_alternative<T>(data_); }
+  constexpr bool has_error() const { return std::holds_alternative<E>(data_); }
+
+  constexpr T& value() & { return std::get<T>(data_); }
+  constexpr const T& value() const& { return std::get<T>(data_); }
+  constexpr T&& value() && { return std::get<T>(std::move(data_)); }
+  constexpr const T& value() const&& { return std::get<T>(std::move(data_)); }
+
+  constexpr E& error() & { return std::get<E>(data_); }
+  constexpr const E& error() const& { return std::get<E>(data_); }
+  constexpr E&& error() && { return std::get<E>(std::move(data_)); }
+  constexpr const E&& error() const&& { return std::get<E>(std::move(data_)); }
+
+ private:
+  std::variant<T, E> data_;
+};
+
+template <typename E>
+class Unexpected {
+ public:
+  constexpr Unexpected(E error) : error_(std::move(error)) {}  // NOLINT
+
+ private:
+  template <typename, typename>
+  friend class Expected;
+
+  E error_;
+};
+
+Unexpected(const char*) -> Unexpected<std::string>;
+
+template <typename T, typename E>
+constexpr Expected<T, E>::Expected(Unexpected<E> u)
+    : data_(std::move(u.error_)) {}
+
+template <typename T>
+class ErrorOr : public Expected<T, Error> {
+ public:
+  using Expected<T, Error>::Expected;
+};
+
+//===----------------------------------------------------------------------===//
+// Future
+//===----------------------------------------------------------------------===//
+
+// A Promise and a Future are loosely based on `std::promise` and `std::future`,
+// with an API similar to `tsl::AsyncValue`. Implementation is based on a
+// simplified version of an AsyncValue with at most one waiter.
+
+// A promise to complete execution with a success or an error.
+class Promise;
+
+// A promise that completes when a specific number of count downs have occurred.
+class CountDownPromise;
+
+// A future that becomes available when a corresponding promise is completed.
+class Future {
+ public:
+  explicit Future(const Promise& promise);
+  explicit Future(const CountDownPromise& promise);
+
+  Future(Future&&) = default;
+  Future& operator=(Future&&) = default;
+
+  template <typename F>
+  void OnReady(F&& f);
+
+ private:
+  friend class Promise;
+
+  using Waiter = std::function<void(const std::optional<Error>& error)>;
+
+  enum class State : uint8_t { kPending, kAvailable, kError };
+
+  struct WaiterAndState {
+    static_assert(alignof(std::max_align_t) >= 8 && sizeof(Waiter*) == 8);
+
+    static constexpr uint64_t kStateMask = (1ull << 2) - 1;
+    static constexpr uint64_t kPointerMask = ~kStateMask;
+
+    WaiterAndState(Waiter* ptr, State state) {
+      value = (reinterpret_cast<uintptr_t>(ptr) & kPointerMask) |
+              (static_cast<uintptr_t>(state) & kStateMask);
+    }
+
+    WaiterAndState() : WaiterAndState(nullptr, State::kPending) {}
+
+    State state() const { return static_cast<State>(value & kStateMask); }
+
+    Waiter* waiter() const {
+      return reinterpret_cast<Waiter*>(value & kPointerMask);
+    }
+
+    uintptr_t value;
+  };
+
+  static_assert(std::atomic<WaiterAndState>::is_always_lock_free,
+                "WaiterAndState atomic must be lock-free");
+
+  struct Data {
+    std::atomic<WaiterAndState> waiter_and_state = WaiterAndState();
+    std::optional<Error> error;
+  };
+
+  std::shared_ptr<Data> data_;
+};
+
+class Promise {
+ public:
+  Promise() : data_(std::make_shared<Future::Data>()) {}
+
+  Promise(const Promise&) = default;
+  Promise& operator=(const Promise&) = default;
+
+  Promise(Promise&&) = default;
+  Promise& operator=(Promise&&) = default;
+
+  void SetAvailable();
+  void SetError(Error error);
+
+ private:
+  friend class Future;
+
+  void SetCompleted(Future::State state);
+
+  std::shared_ptr<Future::Data> data_;
+};
+
+// A simple implementation of `tsl::CountDownAsyncValueRef` that is compatible
+// with `ffi::Future`.
+class CountDownPromise {
+ public:
+  CountDownPromise() = default;
+
+  CountDownPromise(Promise promise, int64_t count)
+      : state_(std::make_shared<State>(std::move(promise), count)) {
+    assert(count > 0 && "Count must be positive");
+  }
+
+  explicit CountDownPromise(int64_t count)
+      : CountDownPromise(Promise(), count) {}
+
+  // Drops the count by `count` and returns true if the underlying promise
+  // became available.
+  bool CountDown(size_t count, const Error& error = Error::Success()) {
+    assert(state_->count.load() >= count && "Invalid count down value");
+
+    if (XLA_FFI_PREDICT_FALSE(!error.success())) {
+      std::lock_guard<std::mutex> lock(state_->mutex);  // NOLINT
+      state_->is_error.store(true, std::memory_order_release);
+      state_->error = error;
+    }
+
+    bool is_complete =
+        state_->count.fetch_sub(count, std::memory_order_acq_rel) == count;
+    if (XLA_FFI_PREDICT_FALSE(is_complete)) {
+      bool is_error = state_->is_error.load(std::memory_order_acquire);
+      if (XLA_FFI_PREDICT_FALSE(is_error)) {
+        auto take_error = [&] {
+          std::lock_guard<std::mutex> lock(state_->mutex);  // NOLINT
+          return state_->error;
+        };
+        state_->promise.SetError(take_error());
+      } else {
+        state_->promise.SetAvailable();
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  // Drops the count by `1` and returns true if the underlying promise became
+  // available.
+  bool CountDown(Error error = Error::Success()) { return CountDown(1, error); }
+
+ private:
+  friend class Future;
+
+  struct State {
+    State(Promise promise, int64_t count)
+        : promise(std::move(promise)), count(count), is_error(false) {}
+
+    Promise promise;
+    std::atomic<int64_t> count;
+    std::atomic<bool> is_error;
+
+    std::mutex mutex;  // NOLINT
+    Error error;
+  };
+
+  std::shared_ptr<State> state_;
+
+  const Promise& AsPromise() const { return state_->promise; }
+};
+
+inline Future::Future(const Promise& promise) : data_(promise.data_) {
+  assert(data_.use_count() == 2 &&
+         "Promise can be used to create at most one Future");
+}
+
+inline Future::Future(const CountDownPromise& promise)
+    : Future(promise.AsPromise()) {}
+
+template <typename F>
+void Future::OnReady(F&& f) {
+  static_assert(std::is_invocable_v<F, const std::optional<Error>&>,
+                "F must be compatible with Waiter signature");
+
+  WaiterAndState old_value =
+      data_->waiter_and_state.load(std::memory_order_acquire);
+
+  // If future is already completed, just run the waiter.
+  if (old_value.state() != State::kPending) {
+    f(data_->error);
+    return;
+  }
+
+  // Otherwise, add the waiter to the future.
+  auto* waiter = new Waiter(std::forward<F>(f));
+  auto new_value = WaiterAndState(waiter, State::kPending);
+
+  while (!data_->waiter_and_state.compare_exchange_weak(
+      old_value, new_value, std::memory_order_acq_rel,
+      std::memory_order_acquire)) {
+    // Another thread completed the future, just run the waiter.
+    if (old_value.state() != State::kPending) {
+      assert(old_value.waiter() == nullptr);
+      (*waiter)(data_->error);
+      delete waiter;
+      return;
+    }
+  }
+
+  // If CAS succeeded the future must be in the pending state.
+  assert(old_value.state() == State::kPending);
+}
+
+inline void Promise::SetAvailable() { SetCompleted(Future::State::kAvailable); }
+
+inline void Promise::SetError(Error error) {
+  assert(error.errc() != ErrorCode::kOk);
+  assert(data_->error == std::nullopt);
+  data_->error = std::move(error);
+
+  SetCompleted(Future::State::kError);
+}
+
+inline void Promise::SetCompleted(Future::State state) {
+  Future::WaiterAndState old_value = data_->waiter_and_state.exchange(
+      {nullptr, state}, std::memory_order_acq_rel);
+  assert(old_value.state() == Future::State::kPending);
+
+  if (Future::Waiter* waiter = old_value.waiter()) {
+    (*waiter)(data_->error);
+    delete waiter;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Arguments
+//===----------------------------------------------------------------------===//
+
+// Dynamically-typed buffer.
+//
+// No checks are done at decoding time. Any dtype and rank combination is
+// accepted.
+class AnyBuffer {
+ public:
+  using Dimensions = Span<const int64_t>;
+
+  explicit AnyBuffer(const XLA_FFI_Buffer* buf) : buf_(buf) {
+    assert(buf != nullptr && "XLA_FFI_Buffer must be non-null");
+  }
+
+  DataType element_type() const { return DataType(buf_->dtype); }
+
+  Dimensions dimensions() const { return Dimensions(buf_->dims, buf_->rank); }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t size_bytes() const {
+    return ByteWidth(element_type()) * element_count();
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t element_count() const {
+    Dimensions dims = dimensions();
+    return std::accumulate(dims.begin(), dims.end(), int64_t{1},
+                           std::multiplies<>());
+  }
+
+  void* untyped_data() const { return buf_->data; }
+
+  template <typename T>
+  T* typed_data() const {
+    assert(internal::NativeTypeToCApiDataType<T>() == buf_->dtype &&
+           "Template type must match the underlying buffer dtype");
+    return reinterpret_cast<T*>(buf_->data);
+  }
+
+  template <typename T>
+  T* reinterpret_data() const {
+    assert(sizeof(T) == ByteWidth(element_type()) &&
+           !(reinterpret_cast<std::uintptr_t>(buf_->data) % alignof(T)) &&
+           "Requested type must have the same byte width and alignment as the "
+           "underlying buffer type");
+    return reinterpret_cast<T*>(buf_->data);
+  }
+
+ private:
+  const XLA_FFI_Buffer* buf_;
+};
+
+namespace internal {
+
+// A workaround for the fact that a static_assertion can be evaluated
+// whether or not the template is instantiated
+template <DataType dtype>
+struct always_false : std::false_type {};
+
+template <DataType dtype>
+struct DataTypeToNative {
+  static_assert(always_false<dtype>::value, "unsupported data type");
+};
+
+#define XLA_FFI_REGISTER_DATATYPE_MAPPING(data_type_value, actual_type) \
+  template <>                                                           \
+  struct DataTypeToNative<data_type_value> {                            \
+    using type = actual_type;                                           \
+  };
+
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::PRED, bool);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::U8, uint8_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::U16, uint16_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::U32, uint32_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::U64, uint64_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::S8, int8_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::S16, int16_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::S32, int32_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::S64, int64_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::F16, uint16_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::F32, float);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::F64, double);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::BF16, uint16_t);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::C64, std::complex<float>);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::C128, std::complex<double>);
+XLA_FFI_REGISTER_DATATYPE_MAPPING(DataType::TOKEN, void);
+
+#undef XLA_FFI_REGISTER_DATATYPE_MAPPING
+
+inline constexpr size_t kDynamicRank = std::numeric_limits<size_t>::max();
+
+}  // namespace internal
+
+constexpr DataType ToComplex(DataType dtype) {
+  switch (dtype) {
+    case DataType::F32:
+      return DataType::C64;
+    case DataType::F64:
+      return DataType::C128;
+    default:
+      return DataType::INVALID;
+  }
+}
+
+constexpr DataType ToReal(DataType dtype) {
+  switch (dtype) {
+    case DataType::C64:
+      return DataType::F32;
+    case DataType::C128:
+      return DataType::F64;
+    default:
+      return dtype;
+  }
+}
+
+constexpr DataType ToImag(DataType dtype) {
+  switch (dtype) {
+    case DataType::C64:
+      return DataType::F32;
+    case DataType::C128:
+      return DataType::F64;
+    default:
+      return dtype;
+  }
+}
+
+template <DataType dtype>
+using NativeType = typename internal::DataTypeToNative<dtype>::type;
+
+template <DataType dtype>
+constexpr bool IsComplexType() {
+  return std::is_same_v<NativeType<dtype>,
+                        std::complex<NativeType<ToReal(dtype)>>>;
+}
+
+static_assert(ToReal(DataType::C64) == DataType::F32);
+static_assert(ToReal(DataType::C128) == DataType::F64);
+static_assert(ToReal(DataType::F32) == DataType::F32);
+static_assert(ToComplex(DataType::F32) == DataType::C64);
+static_assert(ToComplex(DataType::F64) == DataType::C128);
+static_assert(ToComplex(DataType::S32) == DataType::INVALID);
+static_assert(ToComplex(ToReal(DataType::C64)) == DataType::C64);
+static_assert(ToComplex(ToImag(DataType::C128)) == DataType::C128);
+static_assert(IsComplexType<DataType::C64>());
+static_assert(IsComplexType<DataType::C128>());
+static_assert(!IsComplexType<DataType::F32>());
+
+// Buffer with a statically-known dtype and rank.
+//
+// The dtype and rank are checked at decoding time. If rank is not specified,
+// any rank is accepted.
+template <DataType dtype, size_t rank = internal::kDynamicRank>
+class Buffer {
+ public:
+  using Dimensions = AnyBuffer::Dimensions;
+
+  explicit Buffer(const XLA_FFI_Buffer* buf) : buf_(buf) {
+    assert(buf_ != nullptr && "XLA_FFI_Buffer must be non-null");
+  }
+
+  DataType element_type() const { return dtype; }
+
+  Dimensions dimensions() const {
+    return Dimensions(buf_->dims,
+                      rank == internal::kDynamicRank ? buf_->rank : rank);
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t size_bytes() const {
+    return ByteWidth(dtype) * element_count();
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE size_t element_count() const {
+    Dimensions dims = dimensions();
+    return std::accumulate(dims.begin(), dims.end(), int64_t{1},
+                           std::multiplies<>());
+  }
+
+  void* untyped_data() const { return buf_->data; }
+
+  NativeType<dtype>* typed_data() const {
+    return reinterpret_cast<NativeType<dtype>*>(untyped_data());
+  }
+
+ private:
+  const XLA_FFI_Buffer* buf_;
+};
+
+// clang-format off
+template <DataType dtype> using BufferR0 = Buffer<dtype, 0>;
+template <DataType dtype> using BufferR1 = Buffer<dtype, 1>;
+template <DataType dtype> using BufferR2 = Buffer<dtype, 2>;
+template <DataType dtype> using BufferR3 = Buffer<dtype, 3>;
+template <DataType dtype> using BufferR4 = Buffer<dtype, 4>;
+// clang-format on
+
+using Token = BufferR0<DataType::TOKEN>;  // NOLINT
+
+namespace internal {
+
+template <DataType dtype, size_t rank>
+XLA_FFI_ATTRIBUTE_ALWAYS_INLINE bool IsaBuffer(XLA_FFI_Buffer* buf) {
+  return static_cast<DataType>(buf->dtype) == dtype &&
+         (rank == internal::kDynamicRank || buf->rank == rank);
+}
+
+template <DataType dtype, size_t rank>
+XLA_FFI_ATTRIBUTE_ALWAYS_INLINE std::optional<Buffer<dtype, rank>> DecodeBuffer(
+    XLA_FFI_Buffer* buf, DiagnosticEngine& diagnostic) {
+  if (auto buf_dtype = static_cast<DataType>(buf->dtype);
+      XLA_FFI_PREDICT_FALSE(buf_dtype != dtype)) {
+    return diagnostic.Emit("Wrong buffer dtype: expected ")
+           << dtype << " but got " << buf_dtype;
+  }
+
+  if constexpr (rank != internal::kDynamicRank) {
+    if (XLA_FFI_PREDICT_FALSE(buf->rank != rank)) {
+      return diagnostic.Emit("Wrong buffer rank: expected ")
+             << rank << " but got " << buf->rank;
+    }
+  }
+
+  return Buffer<dtype, rank>(buf);
+}
+
+}  // namespace internal
+
+template <DataType dtype, size_t rank = internal::kDynamicRank>
+using ResultBuffer = Result<Buffer<dtype, rank>>;
+
+// clang-format off
+template <DataType dtype> using ResultBufferR0 = ResultBuffer<dtype, 0>;
+template <DataType dtype> using ResultBufferR1 = ResultBuffer<dtype, 1>;
+template <DataType dtype> using ResultBufferR2 = ResultBuffer<dtype, 2>;
+template <DataType dtype> using ResultBufferR3 = ResultBuffer<dtype, 3>;
+template <DataType dtype> using ResultBufferR4 = ResultBuffer<dtype, 4>;
+// clang-format on
+
+//===----------------------------------------------------------------------===//
+// Arguments binding
+//===----------------------------------------------------------------------===//
+
+template <>
+struct ArgBinding<AnyBuffer> {
+  using Arg = AnyBuffer;
+};
+
+template <DataType dtype, size_t rank>
+struct ArgBinding<Buffer<dtype, rank>> {
+  using Arg = Buffer<dtype, rank>;
+};
+
+//===----------------------------------------------------------------------===//
+// Results binding
+//===----------------------------------------------------------------------===//
+
+template <>
+struct RetBinding<Result<AnyBuffer>> {
+  using Ret = AnyBuffer;
+};
+
+template <DataType dtype, size_t rank>
+struct RetBinding<Result<Buffer<dtype, rank>>> {
+  using Ret = Buffer<dtype, rank>;
+};
+
+//===----------------------------------------------------------------------===//
+// Arguments decoding
+//===----------------------------------------------------------------------===//
+
+inline std::ostream& operator<<(std::ostream& os, const XLA_FFI_ArgType type) {
+  switch (type) {
+    case XLA_FFI_ArgType_BUFFER:
+      return os << "buffer";
+  }
+}
+
+template <>
+struct ArgDecoding<AnyBuffer> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static bool Isa(XLA_FFI_ArgType type, void* arg) {
+    return type == XLA_FFI_ArgType_BUFFER;
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<AnyBuffer> Decode(XLA_FFI_ArgType type, void* arg,
+                                         DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_ArgType_BUFFER)) {
+      return diagnostic.Emit("Wrong argument type: expected ")
+             << XLA_FFI_ArgType_BUFFER << " but got " << type;
+    }
+    return AnyBuffer(reinterpret_cast<XLA_FFI_Buffer*>(arg));
+  }
+};
+
+template <DataType dtype, size_t rank>
+struct ArgDecoding<Buffer<dtype, rank>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static bool Isa(XLA_FFI_ArgType type, void* arg) {
+    return type == XLA_FFI_ArgType_BUFFER &&
+           internal::IsaBuffer<dtype, rank>(
+               reinterpret_cast<XLA_FFI_Buffer*>(arg));
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Buffer<dtype, rank>> Decode(
+      XLA_FFI_ArgType type, void* arg, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_ArgType_BUFFER)) {
+      return diagnostic.Emit("Wrong argument type: expected ")
+             << XLA_FFI_ArgType_BUFFER << " but got " << type;
+    }
+
+    return internal::DecodeBuffer<dtype, rank>(
+        reinterpret_cast<XLA_FFI_Buffer*>(arg), diagnostic);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing a variable number of arguments.
+//===----------------------------------------------------------------------===//
+
+class RemainingArgs : public internal::RemainingArgsBase {
+ public:
+  using internal::RemainingArgsBase::RemainingArgsBase;
+
+  template <typename T>
+  ErrorOr<T> get(size_t index) const {
+    size_t idx = offset() + index;
+    if (XLA_FFI_PREDICT_FALSE(idx >= args()->size)) {
+      return Unexpected(
+          Error(ErrorCode::kInvalidArgument, "Index out of range"));
+    }
+
+    DiagnosticEngine diagnostic;
+    std::optional<T> value = ArgDecoding<T>::Decode(
+        args()->types[idx], args()->args[idx], diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+
+    return *value;
+  }
+};
+
+template <>
+struct internal::Decode<internal::RemainingArgsTag> {
+  static std::optional<RemainingArgs> call(DecodingOffsets& offsets,
+                                           DecodingContext& ctx,
+                                           DiagnosticEngine& diagnostic) {
+    return RemainingArgs(&ctx.call_frame->args, offsets.args);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Results decoding
+//===----------------------------------------------------------------------===//
+
+inline std::ostream& operator<<(std::ostream& os, const XLA_FFI_RetType type) {
+  switch (type) {
+    case XLA_FFI_RetType_BUFFER:
+      return os << "buffer";
+  }
+}
+
+template <>
+struct RetDecoding<AnyBuffer> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static bool Isa(XLA_FFI_RetType type, void* ret) {
+    return type == XLA_FFI_RetType_BUFFER;
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Result<AnyBuffer>> Decode(XLA_FFI_RetType type,
+                                                 void* ret,
+                                                 DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_RetType_BUFFER)) {
+      return diagnostic.Emit("Wrong result type: expected ")
+             << XLA_FFI_RetType_BUFFER << " but got " << type;
+    }
+    return AnyBuffer(reinterpret_cast<XLA_FFI_Buffer*>(ret));
+  }
+};
+
+template <DataType dtype, size_t rank>
+struct RetDecoding<Buffer<dtype, rank>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static bool Isa(XLA_FFI_RetType type, void* ret) {
+    return type == XLA_FFI_RetType_BUFFER &&
+           internal::IsaBuffer<dtype, rank>(
+               reinterpret_cast<XLA_FFI_Buffer*>(ret));
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Result<Buffer<dtype, rank>>> Decode(
+      XLA_FFI_RetType type, void* ret, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_RetType_BUFFER)) {
+      return diagnostic.Emit("Wrong result type: expected ")
+             << XLA_FFI_RetType_BUFFER << " but got " << type;
+    }
+
+    return internal::DecodeBuffer<dtype, rank>(
+        reinterpret_cast<XLA_FFI_Buffer*>(ret), diagnostic);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing a variable number of results.
+//===----------------------------------------------------------------------===//
+
+class RemainingRets : public internal::RemainingRetsBase {
+ public:
+  using internal::RemainingRetsBase::RemainingRetsBase;
+
+  template <typename T>
+  ErrorOr<Result<T>> get(size_t index) const {
+    size_t idx = offset() + index;
+    if (XLA_FFI_PREDICT_FALSE(idx >= rets()->size)) {
+      return Unexpected(
+          Error(ErrorCode::kInvalidArgument, "Index out of range"));
+    }
+
+    DiagnosticEngine diagnostic;
+    std::optional<Result<T>> value = RetDecoding<T>::Decode(
+        rets()->types[idx], rets()->rets[idx], diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+
+    return *value;
+  }
+};
+
+template <>
+struct internal::Decode<internal::RemainingRetsTag> {
+  static std::optional<RemainingRets> call(DecodingOffsets& offsets,
+                                           DecodingContext& ctx,
+                                           DiagnosticEngine& diagnostic) {
+    return RemainingRets(&ctx.call_frame->rets, offsets.rets);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Attributes decoding
+//===----------------------------------------------------------------------===//
+
+#define XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(T, TYPE)                       \
+  template <>                                                               \
+  struct AttrDecoding<Span<const T>> {                                      \
+    using Type = Span<const T>;                                             \
+                                                                            \
+    XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(      \
+        XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {  \
+      if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_ARRAY)) {          \
+        return diagnostic.Emit("Wrong attribute type: expected ")           \
+               << XLA_FFI_AttrType_ARRAY << " but got " << type;            \
+      }                                                                     \
+                                                                            \
+      auto* array = reinterpret_cast<XLA_FFI_Array*>(attr);                 \
+      if (XLA_FFI_PREDICT_FALSE(array->dtype != TYPE)) {                    \
+        return diagnostic.Emit("Wrong array data type: expected ")          \
+               << TYPE << " but got " << array->dtype;                      \
+      }                                                                     \
+                                                                            \
+      return Span<const T>(reinterpret_cast<T*>(array->data), array->size); \
+    }                                                                       \
+  }
+
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int8_t, XLA_FFI_DataType_S8);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int16_t, XLA_FFI_DataType_S16);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int32_t, XLA_FFI_DataType_S32);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(int64_t, XLA_FFI_DataType_S64);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(uint8_t, XLA_FFI_DataType_U8);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(uint16_t, XLA_FFI_DataType_U16);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(uint32_t, XLA_FFI_DataType_U32);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(uint64_t, XLA_FFI_DataType_U64);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(float, XLA_FFI_DataType_F32);
+XLA_FFI_REGISTER_ARRAY_ATTR_DECODING(double, XLA_FFI_DataType_F64);
+
+#undef XLA_FFI_REGISTER_ARRAY_ATTR_DECODING
+
+template <>
+struct AttrDecoding<std::string_view> {
+  using Type = std::string_view;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static bool Isa(XLA_FFI_AttrType type,
+                                                  void* attr) {
+    return type == XLA_FFI_AttrType_STRING;
+  }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<std::string_view> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_STRING)) {
+      return diagnostic.Emit("Wrong attribute type: expected ")
+             << XLA_FFI_AttrType_STRING << " but got " << type;
+    }
+
+    auto* span = reinterpret_cast<XLA_FFI_ByteSpan*>(attr);
+    return std::string_view(span->ptr, span->len);
+  }
+};
+
+// A type tag to mark i64 attributes as pointers to `T`.
+template <typename T>
+struct Pointer {};
+
+template <typename T>
+struct AttrDecoding<Pointer<T>> {
+  using Type = T*;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    auto* scalar = reinterpret_cast<XLA_FFI_Scalar*>(attr);
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_SCALAR ||
+                              scalar->dtype != XLA_FFI_DataType_S64)) {
+      return diagnostic.Emit("Wrong attribute type: ")
+             << "expected i64 scalar for passing pointer but got " << type;
+    }
+
+    static_assert(sizeof(uintptr_t) == sizeof(int64_t));
+    uintptr_t ptr = *reinterpret_cast<uintptr_t*>(scalar->value);
+    return reinterpret_cast<Type>(ptr);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing dictionary attributes.
+//===----------------------------------------------------------------------===//
+
+class Dictionary : public internal::DictionaryBase {
+ public:
+  using internal::DictionaryBase::DictionaryBase;
+
+  template <typename T>
+  ErrorOr<T> get(const Iterator& it) const {
+    DiagnosticEngine diagnostic;
+    auto value = internal::DictionaryBase::get<T>(it, diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+    return *value;
+  }
+
+  template <typename T>
+  ErrorOr<T> get(std::string_view name) const {
+    DiagnosticEngine diagnostic;
+    auto value = internal::DictionaryBase::get<T>(name, diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+    return *value;
+  }
+};
+
+// Decode `AttrsTag` (all attributes) into a `Dictionary`.
+template <>
+struct internal::Decode<internal::AttrsTag<Dictionary>> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Dictionary> call(
+      DecodingOffsets& offsets, DecodingContext& ctx,
+      DiagnosticEngine& diagnostic) {
+    return Dictionary(&ctx.call_frame->attrs);
+  }
+};
+
+// Decode individual attribute into `Dictionary` type.
+template <>
+struct AttrDecoding<Dictionary> {
+  using Type = Dictionary;
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Dictionary> Decode(
+      XLA_FFI_AttrType type, void* attr, DiagnosticEngine& diagnostic) {
+    if (XLA_FFI_PREDICT_FALSE(type != XLA_FFI_AttrType_DICTIONARY)) {
+      return diagnostic.Emit("Wrong attribute type: expected ")
+             << XLA_FFI_AttrType_DICTIONARY << " but got " << type;
+    }
+    return Dictionary(reinterpret_cast<XLA_FFI_Attrs*>(attr));
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Type-safe wrapper for accessing context.
+//===----------------------------------------------------------------------===//
+
+class Context : public internal::ContextBase {
+ public:
+  using internal::ContextBase::ContextBase;
+
+  template <typename T>
+  ErrorOr<typename CtxDecoding<T>::Type> get() const {
+    DiagnosticEngine diagnostic;
+    auto value = internal::ContextBase::get<T>(diagnostic);
+    if (XLA_FFI_PREDICT_FALSE(!value.has_value())) {
+      return Unexpected(Error::Internal(diagnostic.Result()));
+    }
+    return *value;
+  }
+};
+
+// Context decoding for catch-all `Context` type.
+template <>
+struct CtxDecoding<Context> {
+  using Type = Context;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Context> Decode(const XLA_FFI_Api* api,
+                                       XLA_FFI_ExecutionContext* ctx,
+                                       DiagnosticEngine&) {
+    return Context(api, ctx);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Error helpers
+//===----------------------------------------------------------------------===//
+
+namespace internal {
+
+inline XLA_FFI_Error* CreateError(const XLA_FFI_Api* api, const Error& error) {
+  XLA_FFI_Error_Create_Args args;
+  args.struct_size = XLA_FFI_Error_Create_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.errc = static_cast<XLA_FFI_Error_Code>(*error.errc());
+  args.message = error.message().c_str();
+  return api->XLA_FFI_Error_Create(&args);
+}
+
+}  // namespace internal
+
+//===----------------------------------------------------------------------===//
+// Result encoding
+//===----------------------------------------------------------------------===//
+
+// Encodes `Error` as an FFI error.
+template <ExecutionStage stage>
+struct ResultEncoding<stage, Error> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static XLA_FFI_Error* Encode(const XLA_FFI_Api* api,
+                               XLA_FFI_ExecutionContext* ctx, Error error) {
+    if (XLA_FFI_PREDICT_TRUE(error.success())) {
+      return nullptr;
+    }
+
+    return internal::CreateError(api, error);
+  }
+};
+
+// Encodes `ErrorOr<std::unique_ptr<T>>` as an FFI state.
+template <typename T, ExecutionStage stage>
+struct ResultEncoding<stage, ErrorOr<std::unique_ptr<T>>> {
+  static_assert(stage != ExecutionStage::kExecute,
+                "Execute stage doesn't support setting a state");
+
+  static_assert(std::is_same_v<decltype(T::id), TypeId>,
+                "State type must have a static `TypeId id` field");
+
+  static XLA_FFI_TypeId state_type_id(const XLA_FFI_Api*) { return T::id; }
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static XLA_FFI_Error* Encode(const XLA_FFI_Api* api,
+                               XLA_FFI_ExecutionContext* ctx,
+                               ErrorOr<std::unique_ptr<T>> state) {
+    if (XLA_FFI_PREDICT_TRUE(state.has_value())) {
+      XLA_FFI_State_Set_Args args;
+      args.struct_size = XLA_FFI_State_Set_Args_STRUCT_SIZE;
+      args.extension_start = nullptr;
+      args.stage = static_cast<XLA_FFI_ExecutionStage>(stage);
+      args.ctx = ctx;
+      args.type_id = &T::id;
+      args.state = state.value().release();
+      return api->XLA_FFI_State_Set(&args);
+    }
+
+    return internal::CreateError(api, state.error());
+  }
+};
+
+// Encodes `Future` as an asynchronous FFI result.
+template <ExecutionStage stage>
+struct ResultEncoding<stage, Future> {
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::variant<XLA_FFI_Error*, XLA_FFI_Future*> Encode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx, Future future) {
+    // Create XLA_FFI_Future object that will signal completion to the runtime.
+    XLA_FFI_Future_Create_Args args;
+    args.struct_size = XLA_FFI_Future_Create_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.future = nullptr;
+
+    if (auto* err = api->XLA_FFI_Future_Create(&args)) {
+      return err;
+    }
+
+    assert(args.future != nullptr && "XLA_FFI_Future_Create failed");
+
+    future.OnReady([api, f = args.future](const std::optional<Error>& error) {
+      // When the OnReady callback is invoked, we no longer have access to the
+      // diagnostics, and can't signal an error to the runtime. We chose to
+      // abort execution, because otherwise it will lead to a deadlock. However
+      // we should never get to this point, because execution must be aborted on
+      // a synchronous path when checking XLA FFI version compatibility.
+      auto abort_on_error = [api](XLA_FFI_Error* err) {
+        if (XLA_FFI_PREDICT_TRUE(err == nullptr)) {
+          return;
+        }
+
+        std::cerr << "Failed to signal XLA_FFI_Future completion: "
+                  << internal::GetErrorMessage(api, err) << std::endl;
+        internal::DestroyError(api, err);
+        std::abort();
+      };
+
+      if (XLA_FFI_PREDICT_FALSE(error.has_value())) {
+        XLA_FFI_Future_SetError_Args args;
+        args.struct_size = XLA_FFI_Future_SetError_Args_STRUCT_SIZE;
+        args.extension_start = nullptr;
+        args.future = f;
+        args.error = internal::CreateError(api, *error);
+
+        abort_on_error(api->XLA_FFI_Future_SetError(&args));
+
+      } else {
+        XLA_FFI_Future_SetAvailable_Args args;
+        args.struct_size = XLA_FFI_Future_SetAvailable_Args_STRUCT_SIZE;
+        args.extension_start = nullptr;
+        args.future = f;
+
+        abort_on_error(api->XLA_FFI_Future_SetAvailable(&args));
+      }
+    });
+
+    return args.future;
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// PlatformStream
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+struct PlatformStream {};
+
+// Context decoding for platform stream.
+//
+// Example: Ffi::Bind().Ctx<PlatformStream<cudaStream_t>()
+//                     .To([](cudaStream_t stream) { ... });
+template <typename T>
+struct CtxDecoding<PlatformStream<T>> {
+  using Type = T;
+
+  static_assert(std::is_pointer_v<T>, "stream type must be a pointer");
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE
+  static std::optional<Type> Decode(const XLA_FFI_Api* api,
+                                    XLA_FFI_ExecutionContext* ctx,
+                                    DiagnosticEngine& diagnostic) {
+    XLA_FFI_Stream_Get_Args args;
+    args.struct_size = XLA_FFI_Stream_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.stream = nullptr;
+
+    if (XLA_FFI_Error* error = api->XLA_FFI_Stream_Get(&args)) {
+      diagnostic.Emit("Failed to get platform stream: ")
+          << internal::GetErrorMessage(api, error);
+      internal::DestroyError(api, error);
+      return std::nullopt;
+    }
+
+    return reinterpret_cast<T>(args.stream);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// ScratchAllocator
+//===----------------------------------------------------------------------===//
+
+// Interface for "scratch" allocator for device memory, which deallocates all
+// buffers it has allocated at destruction.
+//
+// WARNING: It is illegal to keep scratch allocator alive after returning from
+// the FFI handler as it relies on execution context whose lifetime is bound to
+// the particular call to FFI handler.
+class ScratchAllocator {
+ public:
+  ~ScratchAllocator();
+
+  ScratchAllocator(ScratchAllocator&&) = default;
+  ScratchAllocator& operator=(ScratchAllocator&&) = delete;
+
+  std::optional<void*> Allocate(size_t size, size_t alignment = 1);
+
+ private:
+  friend struct CtxDecoding<ScratchAllocator>;
+
+  ScratchAllocator(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+                   DiagnosticEngine& diagnostic);
+
+  struct Allocation {
+    size_t size;
+    void* data;
+  };
+
+  const XLA_FFI_Api* api_;
+  XLA_FFI_ExecutionContext* ctx_;
+
+  DiagnosticEngine& diagnostic_;
+  std::vector<Allocation> allocations_;
+};
+
+// Context decoding for scratch allocator.
+//
+// Example: Ffi::Bind().Ctx<ScratchAllocator>()
+//                     .To([](ScratchAllocator scratch) { ... });
+template <>
+struct CtxDecoding<ScratchAllocator> {
+  using Type = ScratchAllocator;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    return ScratchAllocator(api, ctx, diagnostic);
+  }
+};
+
+inline std::optional<void*> ScratchAllocator::Allocate(size_t size,
+                                                       size_t alignment) {
+  XLA_FFI_DeviceMemory_Allocate_Args args;
+  args.struct_size = XLA_FFI_DeviceMemory_Allocate_Args_STRUCT_SIZE;
+  args.extension_start = nullptr;
+  args.ctx = ctx_;
+  args.size = size;
+  args.alignment = alignment;
+  args.data = nullptr;
+  if (XLA_FFI_Error* error = api_->XLA_FFI_DeviceMemory_Allocate(&args)) {
+    diagnostic_.Emit("Failed to allocate scratch memory: ")
+        << internal::GetErrorMessage(api_, error);
+    internal::DestroyError(api_, error);
+    return std::nullopt;
+  }
+  allocations_.push_back({size, args.data});
+  return args.data;
+}
+
+inline ScratchAllocator::ScratchAllocator(const XLA_FFI_Api* api,
+                                          XLA_FFI_ExecutionContext* ctx,
+                                          DiagnosticEngine& diagnostic)
+    : api_(api), ctx_(ctx), diagnostic_(diagnostic) {}
+
+inline ScratchAllocator::~ScratchAllocator() {
+  for (Allocation& alloc : allocations_) {
+    XLA_FFI_DeviceMemory_Free_Args args;
+    args.struct_size = XLA_FFI_DeviceMemory_Free_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx_;
+    args.size = alloc.size;
+    args.data = alloc.data;
+    if (XLA_FFI_Error* error = api_->XLA_FFI_DeviceMemory_Free(&args)) {
+      diagnostic_.Emit("Failed to free scratch memory: ")
+          << internal::GetErrorMessage(api_, error);
+      internal::DestroyError(api_, error);
+    }
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// ThreadPool
+//===----------------------------------------------------------------------===//
+
+class ThreadPool {
+ public:
+  template <typename F>
+  void Schedule(F&& f) {
+    XLA_FFI_Task* task = +[](void* data) {
+      auto* f = reinterpret_cast<F*>(data);
+      (*f)();
+      delete f;
+    };
+
+    F* data = new F(std::forward<F>(f));
+
+    XLA_FFI_ThreadPool_Schedule_Args args;
+    args.struct_size = XLA_FFI_ThreadPool_Schedule_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx_;
+    args.task = task;
+    args.data = data;
+
+    if (XLA_FFI_Error* error = api_->XLA_FFI_ThreadPool_Schedule(&args)) {
+      diagnostic_.Emit("Failed to schedule task on a thread pool: ")
+          << internal::GetErrorMessage(api_, error);
+      internal::DestroyError(api_, error);
+
+      // If thread pool is not available, we execute the task in the caller
+      // thread. We choose not to return error from `Schedule` for consistency
+      // with Eigen thread pool implementation, and because it would make
+      // recursive work scheduling more difficult.
+      task(data);
+    }
+  }
+
+  int64_t num_threads() const {
+    int64_t num_threads = 0;
+
+    XLA_FFI_ThreadPool_NumThreads_Args args;
+    args.struct_size = XLA_FFI_ThreadPool_NumThreads_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx_;
+    args.num_threads = &num_threads;
+
+    // Silently ignore errors if we can't get the number of threads.
+    if (XLA_FFI_Error* error = api_->XLA_FFI_ThreadPool_NumThreads(&args)) {
+      internal::DestroyError(api_, error);
+    }
+
+    return num_threads;
+  }
+
+ private:
+  friend struct CtxDecoding<ThreadPool>;
+
+  ThreadPool(const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+             DiagnosticEngine& diagnostic);
+
+  const XLA_FFI_Api* api_;
+  XLA_FFI_ExecutionContext* ctx_;
+  DiagnosticEngine& diagnostic_;
+};
+
+// Context decoding for thread pool.
+//
+// Example: Ffi::Bind().Ctx<ThreadPool>()
+//                     .To([](ThreadPool thread_pool) { ... });
+template <>
+struct CtxDecoding<ThreadPool> {
+  using Type = ThreadPool;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    return ThreadPool(api, ctx, diagnostic);
+  }
+};
+
+inline ThreadPool::ThreadPool(const XLA_FFI_Api* api,
+                              XLA_FFI_ExecutionContext* ctx,
+                              DiagnosticEngine& diagnostic)
+    : api_(api), ctx_(ctx), diagnostic_(diagnostic) {}
+
+//===----------------------------------------------------------------------===//
+// Type Registration
+//===----------------------------------------------------------------------===//
+
+template <typename T>
+constexpr XLA_FFI_TypeInfo MakeTypeInfo() {
+  return XLA_FFI_TypeInfo{
+      XLA_FFI_TypeInfo_STRUCT_SIZE,
+      /*extension_start=*/nullptr,
+      /*deleter=*/[](void* ptr) { delete static_cast<T*>(ptr); },
+  };
+}
+
+#define XLA_FFI_REGISTER_TYPE(API, NAME, TYPE_ID, TYPE_INFO) \
+  XLA_FFI_REGISTER_TYPE_(API, NAME, TYPE_ID, TYPE_INFO, __COUNTER__)
+#define XLA_FFI_REGISTER_TYPE_(API, NAME, TYPE_ID, TYPE_INFO, N) \
+  XLA_FFI_REGISTER_TYPE__(API, NAME, TYPE_ID, TYPE_INFO, N)
+#define XLA_FFI_REGISTER_TYPE__(API, NAME, TYPE_ID, TYPE_INFO, N)             \
+  [[maybe_unused]] static const bool xla_ffi_type_##N##_registered_ = [] {    \
+    if (XLA_FFI_Error* error =                                                \
+            ::xla::ffi::Ffi::RegisterTypeId(API, NAME, TYPE_ID, TYPE_INFO)) { \
+      std::cerr << "Failed to register XLA FFI type: "                        \
+                << ::xla::ffi::internal::GetErrorMessage(API, error)          \
+                << std::endl;                                                 \
+      ::xla::ffi::internal::DestroyError(API, error);                         \
+      std::abort();                                                           \
+    }                                                                         \
+    return true;                                                              \
+  }()
+
+//===----------------------------------------------------------------------===//
+// UserData
+//===----------------------------------------------------------------------===//
+
+// A type tag for automatic user data decoding passed via the execution
+// context.
+template <typename T>
+struct UserData {};
+
+// Context decoding for user data of type `T`.
+//
+// Example: Ffi::Bind().Ctx<UserData<MyData>>()
+//                     .To([](MyData* data) { ... });
+template <typename T>
+struct CtxDecoding<UserData<T>> {
+  using Type = T*;
+
+  static_assert(std::is_same_v<decltype(T::id), TypeId>,
+                "UserData type must have a static `TypeId id` field");
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    XLA_FFI_ExecutionContext_Get_Args args;
+    args.struct_size = XLA_FFI_ExecutionContext_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.type_id = &T::id;
+    args.data = nullptr;
+
+    assert(args.type_id->type_id > 0 && "type must be registered with XLA FFI");
+
+    if (XLA_FFI_Error* err = api->XLA_FFI_ExecutionContext_Get(&args); err) {
+      diagnostic.Emit("Failed to get user data from execution context: ")
+          << internal::GetErrorMessage(api, err);
+      internal::DestroyError(api, err);
+      return std::nullopt;
+    }
+
+    return static_cast<Type>(args.data);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// State
+//===----------------------------------------------------------------------===//
+
+// A type tag for automatic state decoding passed via the execution context.
+template <typename T, ExecutionStage stage = ExecutionStage::kInstantiate>
+struct State {};
+
+template <typename T>
+using Prepared = State<T, ExecutionStage::kPrepare>;
+
+template <typename T>
+using Initialized = State<T, ExecutionStage::kInitialize>;
+
+// Context decoding for state of type `T`.
+//
+// Example: Ffi::Bind().Ctx<State<MyState>>()
+//                     .To([](MyState* state) { ... });
+template <typename T, ExecutionStage stage>
+struct CtxDecoding<State<T, stage>> {
+  using Type = T*;
+
+  static_assert(std::is_same_v<decltype(T::id), TypeId>,
+                "State type must have a static `TypeId id` field");
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    XLA_FFI_State_Get_Args args;
+    args.struct_size = XLA_FFI_State_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.stage = static_cast<XLA_FFI_ExecutionStage>(stage);
+    args.ctx = ctx;
+    args.type_id = &T::id;
+    args.state = nullptr;
+
+    assert(args.type_id->type_id > 0 && "type must be registered with XLA FFI");
+
+    if (XLA_FFI_Error* err = api->XLA_FFI_State_Get(&args); err) {
+      diagnostic.Emit("Failed to get state from execution context: ")
+          << internal::GetErrorMessage(api, err);
+      internal::DestroyError(api, err);
+      return std::nullopt;
+    }
+
+    return static_cast<Type>(args.state);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// RunId
+//===----------------------------------------------------------------------===//
+
+struct RunId {
+  int64_t run_id;
+};
+
+// Context decoding for RunId (unique identifier of a logical execution).
+//
+// Example: Ffi::Bind().Ctx<RunId>()
+//                     .To([](RunId run_id) { ... });
+template <>
+struct CtxDecoding<RunId> {
+  using Type = RunId;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    XLA_FFI_RunId_Get_Args args;
+    args.struct_size = XLA_FFI_ExecutionContext_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.run_id = 0;
+
+    if (XLA_FFI_Error* err = api->XLA_FFI_RunId_Get(&args); err) {
+      diagnostic.Emit("Failed to get run id from execution context: ")
+          << internal::GetErrorMessage(api, err);
+      internal::DestroyError(api, err);
+      return std::nullopt;
+    }
+
+    return RunId{args.run_id};
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// DeviceOrdinal
+//===----------------------------------------------------------------------===//
+
+struct DeviceOrdinal {};
+
+// Context decoding for DeviceOrdinal.
+//
+// Example: Ffi::Bind().Ctx<DeviceOrdinal>()
+//                     .To([](int32_t device_ordinal) { ... });
+template <>
+struct CtxDecoding<DeviceOrdinal> {
+  using Type = int32_t;
+
+  XLA_FFI_ATTRIBUTE_ALWAYS_INLINE static std::optional<Type> Decode(
+      const XLA_FFI_Api* api, XLA_FFI_ExecutionContext* ctx,
+      DiagnosticEngine& diagnostic) {
+    XLA_FFI_DeviceOrdinal_Get_Args args;
+    args.struct_size = XLA_FFI_DeviceOrdinal_Get_Args_STRUCT_SIZE;
+    args.extension_start = nullptr;
+    args.ctx = ctx;
+    args.device_ordinal = 0;
+
+    if (XLA_FFI_Error* err = api->XLA_FFI_DeviceOrdinal_Get(&args); err) {
+      diagnostic.Emit("Failed to get device ordinal from execution context: ")
+          << internal::GetErrorMessage(api, err);
+      internal::DestroyError(api, err);
+      return std::nullopt;
+    }
+
+    return args.device_ordinal;
+  }
+};
+
+}  // namespace xla::ffi
+
+#endif  // XLA_FFI_API_FFI_H_

--- a/lib/chacha_kernels.hpp
+++ b/lib/chacha_kernels.hpp
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2023 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #pragma once
 
 
 // cpu_kernel.cpp
-extern void cpu_chacha20_block(void* out_buffer, const void** in_buffers);
+void cpu_chacha20_block(uint32_t num_states, const uint32_t* state_buffer, uint32_t* result_buffer);
 
 #if (CUDA_ENABLED || HIP_ENABLED)
     #ifdef CUDA_ENABLED
@@ -19,5 +19,5 @@ extern void cpu_chacha20_block(void* out_buffer, const void** in_buffers);
     #endif // HIP_ENABLED
 
     // gpu_kernel.cpp.cu
-    extern void gpu_chacha20_block(gpuStream_t stream, void** buffers, const char* opaque, std::size_t opaque_length);
+    extern void gpu_chacha20_block(gpuStream_t stream, uint32_t num_states, const uint32_t* in_states, uint32_t* out_states);
 #endif // (CUDA_ENABLED || HIP_ENABLED)

--- a/lib/cpu_kernel.cpp
+++ b/lib/cpu_kernel.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2022 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #include "cpu_kernel.hpp"
 
@@ -103,17 +103,14 @@ void chacha20_block(uint32_t out_state[16], const uint32_t in_state[16])
     vec_tmp_state.unvectorize(out_state);
 }
 
-void cpu_chacha20_block(void* out_buffer, const void** in_buffers)
+void cpu_chacha20_block(uint32_t num_states, const uint32_t* state_buffer, uint32_t* result_buffer)
 {
-    uint32_t num_states = *reinterpret_cast<const uint32_t*>(in_buffers[0]);
-    const uint32_t* in_states = reinterpret_cast<const uint32_t*>(in_buffers[1]);
-    uint32_t* out_state = reinterpret_cast<uint32_t*>(out_buffer);
     #ifdef OPENMP_AVAILABLE
     #pragma omp parallel for
     #endif
     for (uint32_t i = 0; i < num_states; ++i)
     {
         uint32_t offset = ChaChaStateSizeInWords * i;
-        chacha20_block(out_state + offset, in_states + offset);
+        chacha20_block(result_buffer + offset, state_buffer + offset);
     }
 }

--- a/lib/cpu_kernel.hpp
+++ b/lib/cpu_kernel.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2022 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #pragma once
 
@@ -57,4 +57,4 @@ public:
 void unpack_diagonals(VectorizedState& out_state, VectorizedState in_state);
 void pack_diagonals(VectorizedState& out_state, VectorizedState in_state);
 void chacha20_block(uint32_t out_state[16], const uint32_t in_state[16]);
-void cpu_chacha20_block(void* out_buffer, const void** in_buffers);
+void cpu_chacha20_block(uint32_t num_states, const uint32_t* state_buffer, uint32_t* result_buffer);

--- a/lib/gpu_kernel.gpu.cpp
+++ b/lib/gpu_kernel.gpu.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2023 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #include <cstdlib>
 #include <stdexcept>
@@ -117,26 +117,11 @@ void chacha20_block_with_shuffle(uint32_t* out_state, const uint32_t* in_state, 
     }
 }
 
-void gpu_chacha20_block(gpuStream_t stream, void** buffers, const char* opaque, std::size_t opaque_length)
+void gpu_chacha20_block(gpuStream_t stream, uint32_t num_states, const uint32_t* in_states, uint32_t* out_states)
 {
-    uint32_t num_states = 1;
-    if (opaque_length > 0)
-    {
-        if (opaque_length != sizeof(uint32_t))
-        {
-            throw std::runtime_error(
-                "gpu_chacha20_block requires the opaque argument to be either null or a pointer to a 32-bit integer "
-                "indicating the number of states on which to operate."
-            );
-        }
-        num_states = *reinterpret_cast<const uint32_t*>(opaque);
-    }
-    const uint32_t* in_states = reinterpret_cast<const uint32_t*>(buffers[0]);
-    uint32_t* out_state = reinterpret_cast<uint32_t*>(buffers[1]);
-
     uint num_threads = (num_states * ThreadsPerState);
     uint num_blocks =  (num_threads + TargetThreadsPerBlock - 1) / TargetThreadsPerBlock; // = ceil(num_threads / TargetThreadsPerBlock)
 
     uint threads_per_block = std::min(num_threads, TargetThreadsPerBlock);
-    chacha20_block_with_shuffle<<<num_blocks, threads_per_block, 0, stream>>>(out_state, in_states, num_threads);
+    chacha20_block_with_shuffle<<<num_blocks, threads_per_block, 0, stream>>>(out_states, in_states, num_threads);
 }

--- a/lib/gpu_kernel.hpp
+++ b/lib/gpu_kernel.hpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2023 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #pragma once
 
@@ -22,4 +22,4 @@
 __global__
 void chacha20_block_with_shuffle(uint32_t* out_state, const uint32_t* in_state, uint num_threads);
 
-void gpu_chacha20_block(gpuStream_t stream, void** buffers, const char* opaque, std::size_t opaque_length);
+void gpu_chacha20_block(gpuStream_t stream, uint32_t num_states, const uint32_t* in_states, uint32_t* out_states);

--- a/lib/python_bindings.cpp
+++ b/lib/python_bindings.cpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2023 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #include <pybind11/pybind11.h>
+#include <xla/ffi/api/ffi.h>
+#include <xla/ffi/api/c_api.h>
+#include <numeric>
 
 #include "chacha_kernels.hpp"
 
@@ -32,14 +35,77 @@ constexpr bool openmp_accelerated()
 #endif
 }
 
+namespace ffi = xla::ffi;
+
+template <ffi::DataType T>
+ffi::Error get_num_states(const ffi::Buffer<T>& buffer, uint32_t *num_states)
+{
+    auto dims = buffer.dimensions();
+    if (dims.size() < 2)
+        return ffi::Error::InvalidArgument("A valid input must have at least two dimensions");
+
+    // uint32_t _num_states = 1;
+
+    uint32_t _num_states = std::accumulate(dims.begin(), dims.end() - 2, 1, std::multiplies<int>());
+
+    // for (size_t i = 0; i < dims.size() - 2; ++i)
+    // {
+    //     _num_states *= dims[i];
+    // }
+    *num_states = _num_states;
+    return ffi::Error::Success();
+}
+
+ffi::Error cpu_chacha20_block_ffi_impl(ffi::Buffer<ffi::U32> state_buffer, ffi::ResultBuffer<ffi::U32> result)
+{
+    uint32_t num_states = 1;
+    auto error = get_num_states(state_buffer, &num_states);
+    if (error.failure())
+        return error;
+
+    cpu_chacha20_block(num_states, state_buffer.typed_data(), result->typed_data());
+    return ffi::Error::Success();
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    cpu_chacha20_block_ffi, cpu_chacha20_block_ffi_impl,
+    ffi::Ffi::Bind()
+        .Arg<ffi::Buffer<ffi::U32>>()  // state_buffer
+        .Ret<ffi::Buffer<ffi::U32>>()  // result
+);
+
+#if (CUDA_ENABLED || HIP_ENABLED)
+ffi::Error gpu_chacha20_block_ffi_impl(gpuStream_t stream, ffi::Buffer<ffi::U32> state_buffer, ffi::ResultBuffer<ffi::U32> result)
+{
+    uint32_t num_states = 1;
+    auto error = get_num_states(state_buffer, &num_states);
+    if (error.failure())
+        return error;
+
+    gpu_chacha20_block(stream, num_states, state_buffer.typed_data(), result->typed_data());
+    return ffi::Error::Success();
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    gpu_chacha20_block_ffi, gpu_chacha20_block_ffi_impl,
+    ffi::Ffi::Bind()
+        .Ctx<ffi::PlatformStream<gpuStream_t>>()
+        .Arg<ffi::Buffer<ffi::U32>>()  // state_buffer
+        .Ret<ffi::Buffer<ffi::U32>>()  // result
+);
+#endif // (CUDA_ENABLED || HIP_ENABLED)
+
 PYBIND11_MODULE(native, m)
 {
     m.def("cpu_chacha20_block_factory",
-          []() { return pybind11::capsule(reinterpret_cast<void*>(cpu_chacha20_block), "xla._CUSTOM_CALL_TARGET"); } );
+          []() { return pybind11::capsule(reinterpret_cast<void*>(cpu_chacha20_block_ffi)); } );
 
-#if (CUDA_ENABLED || HIP_ENABLED)
-    m.def("gpu_chacha20_block_factory",
-          []() { return pybind11::capsule(reinterpret_cast<void*>(gpu_chacha20_block), "xla._CUSTOM_CALL_TARGET"); });
+#if (CUDA_ENABLED)
+    m.def("cuda_chacha20_block_factory",
+          []() { return pybind11::capsule(reinterpret_cast<void*>(gpu_chacha20_block_ffi)); });
+#elif (HIP_ENABLED)
+    m.def("rocm_chacha20_block_factory",
+          []() { return pybind11::capsule(reinterpret_cast<void*>(gpu_chacha20_block_ffi)); });
 #endif // (CUDA_ENABLED || HIP_ENABLED)
 
     m.def("cuda_supported", &cuda_supported, "Returns true if CUDA GPU kernels were compiled.");

--- a/setup.py
+++ b/setup.py
@@ -83,9 +83,9 @@ spec = importlib.util.spec_from_file_location("version_module", "chacha/version.
 version_module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(version_module)
 
-_jax_version_lower_constraint = ' >= 0.4.1'
-_jax_version_optimistic_upper_constraint = ', <= 2.0.0'
-_jax_version_upper_constraint = ', <= 0.4.14'
+_jax_version_lower_constraint = ' >= 0.10.0'
+_jax_version_optimistic_upper_constraint = ', <= 1.0.0'
+_jax_version_upper_constraint = ', < 0.11'
 
 _version = version_module.VERSION
 if 'JAX_CHACHA_PRNG_BUILD' in os.environ:
@@ -103,7 +103,7 @@ setuptools.setup(
     packages=setuptools.find_packages(include=['chacha', 'chacha.*']),
     python_requires='>=3.8',
     install_requires=[
-        "numpy >= 1.16, < 2",
+        "numpy >= 1.16, < 3",
         "deprecation < 3",
         f"jax{_jax_version_lower_constraint}{_jax_version_optimistic_upper_constraint}"
     ],

--- a/tests/lib/cpu_kernel_tests.cpp
+++ b/tests/lib/cpu_kernel_tests.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2021 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #include <iostream>
 
@@ -245,9 +245,7 @@ int test_cpu_chacha20_block()
     std::array<uint32_t, ChaChaStateSizeInWords> single_block_output;
     uint32_t num_inputs = 1;
 
-    std::array<const void*, 2> inputs({&num_inputs, single_block_input.data()});
-
-    cpu_chacha20_block(single_block_output.data(), inputs.data());
+    cpu_chacha20_block(num_inputs, single_block_input.data(), single_block_output.data());
 
     num_fails += test_assert(single_block_output == test_vector_expected[0]);
 
@@ -259,9 +257,7 @@ int test_cpu_chacha20_block()
         multiple_block_input.begin());
     it = std::copy(test_vector_states[0].cbegin(), test_vector_states[0].cend(), it);
 
-    inputs = {&num_inputs, multiple_block_input.data()};
-
-    cpu_chacha20_block(multiple_block_output.data(), inputs.data());
+    cpu_chacha20_block(num_inputs, multiple_block_input.data(), multiple_block_output.data());
 
     num_fails += test_assert(
         std::equal(test_vector_expected[0].cbegin(), test_vector_expected[0].cend(),
@@ -278,9 +274,7 @@ int test_cpu_chacha20_block()
         multiple_block_input.begin());
     it = std::copy(test_vector_states[3].cbegin(), test_vector_states[3].cend(), it);
 
-    inputs = {&num_inputs, multiple_block_input.data()};
-
-    cpu_chacha20_block(multiple_block_output.data(), inputs.data());
+    cpu_chacha20_block(num_inputs, multiple_block_input.data(), multiple_block_output.data());
 
     num_fails += test_assert(
         std::equal(test_vector_expected[1].cbegin(), test_vector_expected[1].cend(),
@@ -299,9 +293,7 @@ int test_cpu_chacha20_block()
     it = std::copy(test_vector_states[2].cbegin(), test_vector_states[2].cend(), it);
     it = std::copy(test_vector_states[5].cbegin(), test_vector_states[5].cend(), it);
 
-    inputs = {&num_inputs, multiple_block_input.data()};
-
-    cpu_chacha20_block(multiple_block_output.data(), inputs.data());
+    cpu_chacha20_block(num_inputs, multiple_block_input.data(), multiple_block_output.data());
 
     num_fails += test_assert(
         std::equal(test_vector_expected[1].cbegin(), test_vector_expected[1].cend(),

--- a/tests/lib/gpu_kernel_tests.gpu.cpp
+++ b/tests/lib/gpu_kernel_tests.gpu.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2023 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #include <iostream>
 #include <array>
@@ -103,11 +103,8 @@ int test_gpu_chacha20_block()
     DeviceBuffer<ChaChaStateSizeInWords> single_block_output_device;
     uint32_t num_inputs = 1;
 
-    std::array<void*, 2> buffers = { single_block_input_device.raw(), single_block_output_device.raw() };
-
     gpu_chacha20_block(
-        /*stream=*/nullptr, buffers.data(), /*opaque=*/reinterpret_cast<const char*>(&num_inputs),
-        /*opaque_length=*/sizeof(num_inputs)
+        /*stream=*/nullptr, num_inputs, single_block_input_device.raw(), single_block_output_device.raw()
     );
 
     std::array<uint32_t, ChaChaStateSizeInWords> single_block_output = single_block_output_device.read();
@@ -124,11 +121,8 @@ int test_gpu_chacha20_block()
     DeviceBuffer<4*ChaChaStateSizeInWords> multiple_block_input_device(multiple_block_input);
     DeviceBuffer<4*ChaChaStateSizeInWords> multiple_block_output_device;
 
-    buffers = { multiple_block_input_device.raw(), multiple_block_output_device.raw() };
-
     gpu_chacha20_block(
-        /*stream=*/nullptr, buffers.data(), /*opaque=*/reinterpret_cast<const char*>(&num_inputs),
-        /*opaque_length=*/sizeof(num_inputs)
+        /*stream=*/nullptr, num_inputs, multiple_block_input_device.raw(), multiple_block_output_device.raw()
     );
 
     multiple_block_output_device.read(multiple_block_output);
@@ -149,11 +143,8 @@ int test_gpu_chacha20_block()
     it = std::copy(test_vector_states[3].cbegin(), test_vector_states[3].cend(), it);
     multiple_block_input_device.write(multiple_block_input);
 
-    buffers = { multiple_block_input_device.raw(), multiple_block_output_device.raw() };
-
     gpu_chacha20_block(
-        /*stream=*/nullptr, buffers.data(), /*opaque=*/reinterpret_cast<const char*>(&num_inputs),
-        /*opaque_length=*/sizeof(num_inputs)
+        /*stream=*/nullptr, num_inputs, multiple_block_input_device.raw(), multiple_block_output_device.raw()
     );
 
     multiple_block_output_device.read(multiple_block_output);
@@ -176,11 +167,8 @@ int test_gpu_chacha20_block()
     it = std::copy(test_vector_states[5].cbegin(), test_vector_states[5].cend(), it);
     multiple_block_input_device.write(multiple_block_input);
 
-    buffers = { multiple_block_input_device.raw(), multiple_block_output_device.raw() };
-
     gpu_chacha20_block(
-        /*stream=*/nullptr, buffers.data(), /*opaque=*/reinterpret_cast<const char*>(&num_inputs),
-        /*opaque_length=*/sizeof(num_inputs)
+        /*stream=*/nullptr, num_inputs, multiple_block_input_device.raw(), multiple_block_output_device.raw()
     );
 
     multiple_block_output_device.read(multiple_block_output);

--- a/tests/lib/tests.hpp
+++ b/tests/lib/tests.hpp
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
-// SPDX-FileCopyrightText: © 2021 Aalto University
+// SPDX-FileCopyrightText: © 2026 Aalto University
 
 #pragma once
 
 #include <iostream>
 #include <array>
 #include <vector>
+#include <cstdint>
 
 #include "defs.hpp"
 

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -194,7 +194,7 @@ class ChaChaRNGTests(unittest.TestCase):
         rng_key = PRNGKey(0)
         sample = random_bits(rng_key, 32, ())
         self.assertEqual((), jnp.shape(sample))
-        self.assertEqual(jnp.uint32, jnp.dtype(sample))
+        self.assertEqual(jnp.uint32, sample.dtype)
 
     def test_random_bits_invalid_width(self) -> None:
         rng_key = PRNGKey(0)


### PR DESCRIPTION
- Registering chacha kernels using the foreign function interface.
- Wheels are now built for CUDA 12 instead of 11

These entail a major shift in the C++/Python interface and leads to incompatibility with JAX versions prior to v0.10.